### PR TITLE
Moving to compute_mode flag to control execution mode

### DIFF
--- a/voxel51/api.py
+++ b/voxel51/api.py
@@ -439,8 +439,7 @@ class API(object):
         return _parse_json_response(res)
 
     def upload_job_request(
-            self, job_request, job_name, auto_start=False, use_gpu=None,
-            ttl=None):
+            self, job_request, job_name, auto_start=False, ttl=None):
         '''Uploads a job request.
 
         Args:
@@ -449,8 +448,6 @@ class API(object):
             job_name (str): a name for the job
             auto_start (bool, optional): whether to automatically start the job
                 upon creation. By default, this is False
-            use_gpu (bool, optional): whether to use GPU resources when running
-                the job. By default, GPU is used if the analytic supports it
             ttl (datetime|str, optional): a TTL for the job output. If none
                 is provided, the default TTL is used. If a string is provided,
                 it must be in ISO 8601 format: "YYYY-MM-DDThh:mm:ss.sssZ"
@@ -467,8 +464,6 @@ class API(object):
             "job_name": (None, job_name),
             "auto_start": (None, str(auto_start)),
         }
-        if use_gpu is not None:
-            files["use_gpu"] = (None, str(use_gpu))
         if ttl is not None:
             if isinstance(ttl, datetime):
                 ttl = ttl.isoformat()

--- a/voxel51/api.py
+++ b/voxel51/api.py
@@ -439,7 +439,7 @@ class API(object):
         return _parse_json_response(res)
 
     def upload_job_request(
-            self, job_request, job_name, auto_start=False, use_gpu=True,
+            self, job_request, job_name, auto_start=False, use_gpu=None,
             ttl=None):
         '''Uploads a job request.
 
@@ -450,7 +450,7 @@ class API(object):
             auto_start (bool, optional): whether to automatically start the job
                 upon creation. By default, this is False
             use_gpu (bool, optional): whether to use GPU resources when running
-                the job. By default, this is True
+                the job. By default, GPU is used if the analytic supports it
             ttl (datetime|str, optional): a TTL for the job output. If none
                 is provided, the default TTL is used. If a string is provided,
                 it must be in ISO 8601 format: "YYYY-MM-DDThh:mm:ss.sssZ"
@@ -466,8 +466,9 @@ class API(object):
             "file": ("job.json", str(job_request), "application/json"),
             "job_name": (None, job_name),
             "auto_start": (None, str(auto_start)),
-            "use_gpu": (None, str(use_gpu)),
         }
+        if use_gpu is not None:
+            files["use_gpu"] = (None, str(use_gpu))
         if ttl is not None:
             if isinstance(ttl, datetime):
                 ttl = ttl.isoformat()

--- a/voxel51/jobs.py
+++ b/voxel51/jobs.py
@@ -27,6 +27,14 @@ import voxel51.utils as voxu
 DATA_ID_FIELD = "data-id"
 
 
+class JobComputeMode(object):
+    '''Enum describing the possible compute modes of a job.'''
+
+    CPU = "cpu"
+    GPU = "gpu"
+    BEST = "best"
+
+
 class JobState(object):
     '''Enum describing the possible states of a job.'''
 
@@ -57,26 +65,26 @@ class JobRequest(voxu.Serializable):
 
     Attributes:
         analytic (str): the name of the analytic to run
-        version (str): the version of the analytic to run (None = latest)
-        use_gpu (bool): whether the job will be executed with GPU (None = CPU)
+        version (str): the version of the analytic to run
+        compute_mode (JobComputeMode): the compute mode for the job
         inputs (dict): a dictionary mapping input names to RemoteDataPath
             instances
         parameters (dict): a dictionary mapping parameter names to values
     '''
 
-    def __init__(self, analytic, version=None, use_gpu=None):
+    def __init__(self, analytic, version=None, compute_mode=None):
         '''Creates a JobRequest instance.
 
         Args:
             analytic (str): the name of the analytic to run
             version (str, optional): the version of the analytic to run. If not
                 specified, the latest available version is used
-            use_gpu (bool, optional): whether to use GPU resources when running
-                the job. By default, CPU is used
+            compute_mode (JobComputeMode, optional): the compute mode to use
+                for the job. By default, JobComputeMode.BEST is used
         '''
         self.analytic = analytic
         self.version = version
-        self.use_gpu = use_gpu
+        self.compute_mode = compute_mode
         self.inputs = {}
         self.parameters = {}
 
@@ -134,8 +142,8 @@ class JobRequest(voxu.Serializable):
         '''
         analytic = d["analytic"]
         version = d.get("version", None)
-        use_gpu = d.get("use_gpu", None)
-        job_request = cls(analytic, version=version, use_gpu=use_gpu)
+        compute_mode = d.get("compute_mode", None)
+        job_request = cls(analytic, version=version, compute_mode=compute_mode)
 
         # Set inputs
         for name, val in iteritems(d["inputs"]):
@@ -158,8 +166,8 @@ class JobRequest(voxu.Serializable):
         attrs["analytic"] = "analytic"
         if self.version is not None:
             attrs["version"] = "version"
-        if self.use_gpu is not None:
-            attrs["use_gpu"] = "use_gpu"
+        if self.compute_mode is not None:
+            attrs["compute_mode"] = "compute_mode"
         attrs["inputs"] = "inputs"
         attrs["parameters"] = "parameters"
         return attrs

--- a/voxel51/jobs.py
+++ b/voxel51/jobs.py
@@ -30,9 +30,9 @@ DATA_ID_FIELD = "data-id"
 class JobComputeMode(object):
     '''Enum describing the possible compute modes of a job.'''
 
-    CPU = "cpu"
-    GPU = "gpu"
-    BEST = "best"
+    CPU = "CPU"
+    GPU = "GPU"
+    BEST = "BEST"
 
 
 class JobState(object):

--- a/voxel51/jobs.py
+++ b/voxel51/jobs.py
@@ -56,21 +56,25 @@ class JobRequest(voxu.Serializable):
     Attributes:
         analytic (str): the name of the analytic to run
         version (str): the version of the analytic to run (None = latest)
+        use_gpu (bool): whether the job will be executed with GPU (None = CPU)
         inputs (dict): a dictionary mapping input names to RemoteDataPath
             instances
         parameters (dict): a dictionary mapping parameter names to values
     '''
 
-    def __init__(self, analytic, version=None):
+    def __init__(self, analytic, version=None, use_gpu=None):
         '''Creates a JobRequest instance.
 
         Args:
             analytic (str): the name of the analytic to run
             version (str, optional): the version of the analytic to run. If not
                 specified, the latest available version is used
+            use_gpu (bool, optional): whether to use GPU resources when running
+                the job. By default, CPU is used
         '''
         self.analytic = analytic
         self.version = version
+        self.use_gpu = use_gpu
         self.inputs = {}
         self.parameters = {}
 
@@ -126,7 +130,10 @@ class JobRequest(voxu.Serializable):
         Returns:
             a JobRequest instance
         '''
-        job_request = cls(d["analytic"])
+        analytic = d["analytic"]
+        version = d.get("version", None)
+        use_gpu = d.get("use_gpu", None)
+        job_request = cls(analytic, version=version, use_gpu=use_gpu)
 
         # Set inputs
         for name, val in iteritems(d["inputs"]):
@@ -141,6 +148,7 @@ class JobRequest(voxu.Serializable):
             else:
                 # Non-data parameter
                 job_request.set_parameter(name, val)
+
         return job_request
 
 

--- a/voxel51/jobs.py
+++ b/voxel51/jobs.py
@@ -19,6 +19,8 @@ from future.utils import iteritems
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
+from collections import OrderedDict
+
 import voxel51.utils as voxu
 
 
@@ -150,6 +152,17 @@ class JobRequest(voxu.Serializable):
                 job_request.set_parameter(name, val)
 
         return job_request
+
+    def _attributes(self):
+        attrs = OrderedDict()
+        attrs["analytic"] = "analytic"
+        if self.version is not None:
+            attrs["version"] = "version"
+        if self.use_gpu is not None:
+            attrs["use_gpu"] = "use_gpu"
+        attrs["inputs"] = "inputs"
+        attrs["parameters"] = "parameters"
+        return attrs
 
 
 class RemoteDataPath(voxu.Serializable):

--- a/voxel51/query.py
+++ b/voxel51/query.py
@@ -235,7 +235,7 @@ class JobsQuery(BaseQuery):
     Attributes:
         fields (list): the list of fields to include in the returned records.
             The supported query fields are `id`, `name`, `state`, `archived`,
-            `upload_date`, `analytic_id`, `auto_start`, `use_gpu`,
+            `upload_date`, `analytic_id`, `auto_start`, `compute_mode`,
             `start_date`, `completion_date`, `fail_date`, and `failure_type`
         search (list): a list of `field:search_str` search strings to apply
         sort (str): a `field:asc/desc` string describing a sorting scheme
@@ -247,5 +247,5 @@ class JobsQuery(BaseQuery):
         '''Initializes a JobsQuery instance.'''
         super(JobsQuery, self).__init__([
             "id", "name", "state", "archived", "upload_date", "analytic_id",
-            "auto_start", "use_gpu", "start_date", "completion_date",
+            "auto_start", "compute_mode", "start_date", "completion_date",
             "fail_date", "failure_type"])


### PR DESCRIPTION
This PR migrates from `use_gpu` to `compute_mode`, and it allows the API itself to be authoritative on how the default `compute_mode` is set, which is desirable for consistency across clients.