### PR TITLE
JSON loads hotfix

### DIFF
--- a/voxel51/api.py
+++ b/voxel51/api.py
@@ -772,16 +772,14 @@ class APIError(Exception):
 
         Raises:
             ValueError: if the given response is not an error response
-            HTTPError: if the error was caused by the HTTP connection, not
-                the API itself
         '''
         if res.ok:
             raise ValueError("Response is not an error")
 
         try:
             message = _parse_json_response(res)["error"]["message"]
-        except ValueError:
-            res.raise_for_status()
+        except:
+            message = '%s for URL: %s' % (res.reason, res.url)
 
         return cls(message, res.status_code)
 

--- a/voxel51/api.py
+++ b/voxel51/api.py
@@ -794,4 +794,4 @@ def _validate_response(res):
 
 
 def _parse_json_response(res):
-    return json.loads(res.content.decode("utf-8"))
+    return voxu.load_json(res.content)

--- a/voxel51/api.py
+++ b/voxel51/api.py
@@ -796,4 +796,4 @@ def _validate_response(res):
 
 
 def _parse_json_response(res):
-    return json.loads(res.content)
+    return json.loads(res.content.decode("utf-8"))

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -23,6 +23,7 @@ import requests
 
 from voxel51.api import API, APIError
 import voxel51.apps.auth as voxa
+import voxel51.utils as voxu
 
 
 class ApplicationAPI(API):
@@ -269,4 +270,4 @@ def _validate_response(res):
 
 
 def _parse_json_response(res):
-    return json.loads(res.content.decode("utf-8"))
+    return voxu.load_json(res.content)

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -269,4 +269,4 @@ def _validate_response(res):
 
 
 def _parse_json_response(res):
-    return json.loads(res.content)
+    return json.loads(res.content.decode("utf-8"))

--- a/voxel51/utils.py
+++ b/voxel51/utils.py
@@ -147,7 +147,7 @@ class Serializable(object):
         Returns:
             an instance of the Serializable subclass
         '''
-        return cls.from_dict(json.loads(s))
+        return cls.from_dict(json.loads(str(s)))
 
     @classmethod
     def from_json(cls, path):

--- a/voxel51/utils.py
+++ b/voxel51/utils.py
@@ -40,6 +40,22 @@ def read_json(path):
         return json.load(f)
 
 
+def load_json(str_or_bytes):
+    '''Loads JSON from string.
+
+    Args:
+        str_or_bytes (str): the input string or bytes
+
+    Returns:
+        a JSON list/dictionary
+    '''
+    try:
+        return json.loads(str_or_bytes)
+    except TypeError:
+        # Must be a Python version for which json.loads() cannot handle bytes
+        return json.loads(str_or_bytes.decode("utf-8"))
+
+
 def json_to_str(obj):
     '''Generates a string representation of the JSON object.
 
@@ -147,7 +163,7 @@ class Serializable(object):
         Returns:
             an instance of the Serializable subclass
         '''
-        return cls.from_dict(json.loads(str(s)))
+        return cls.from_dict(load_json(s))
 
     @classmethod
     def from_json(cls, path):


### PR DESCRIPTION
This fixes https://github.com/voxel51/api-py/issues/40, once and for all.

The issue that @mattphotonman was facing was that `json.loads` does not handle bytes in Python 3.5, while it DOES handle bytes in Python 2.7, 3.6, and 3.7. So, the simple fix is to manually decode the bytes before calling `json.loads`.