### PR TITLE
Moving platform user functionality to a `users` subpackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Alternatively, you can permanently activate a token by executing the following
 commands:
 
 ```py
-from voxel51.auth import activate_token
+from voxel51.users.auth import activate_token
 
 activate_token("/path/to/your/api-token.json")
 ```
 
 In the latter case, your token is copied to `~/.voxel51/` and will be
 automatically used in all future sessions. A token can be deactivated via the
-`voxel51.auth.deactivate_token()` method.
+:func:`voxel51.users.auth.deactivate_token` method.
 
 After you have activated an API token, you have full access to the API.
 
@@ -74,7 +74,7 @@ After you have activated an API token, you have full access to the API.
 To initialize an API session, issue the following commands:
 
 ```py
-from voxel51.api import API
+from voxel51.users.api import API
 
 api = API()
 ```
@@ -126,7 +126,7 @@ the name of the analytic to run, `<data-id>` is the ID of the data to process,
 and any `<param>` values are set as necessary to configre the analytic:
 
 ```py
-from voxel51.jobs import JobRequest
+from voxel51.users.jobs import JobRequest
 
 job_request = JobRequest("<analytic>")
 job_request.set_input("<input>", data_id="<data-id>")
@@ -199,7 +199,8 @@ activate_application_token("/path/to/your/app-token.json")
 
 In the latter case, your token is copied to `~/.voxel51/` and will be
 automatically used in all future sessions. An application token can be
-deactivated via the `voxel51.apps.auth.deactivate_application_token()` method.
+deactivated via the :func:`voxel51.apps.auth.deactivate_application_token`
+method.
 
 After you have activated an application API token, you have full access to the
 API.
@@ -256,7 +257,7 @@ api.upload_data(data_path)
 And run a job on the user's data:
 
 ```py
-from voxel51.jobs import JobRequest
+from voxel51.users.jobs import JobRequest
 
 job_request = JobRequest("<analytic>")
 job_request.set_input("<input>", data_id="<data-id>")

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="voxel51-api-python",
-    version="1.0.0",
+    version="0.1.0",
     description="Python client library for the Voxel51 Platform API",
     author="Voxel51, Inc.",
     author_email="support@voxel51.com",

--- a/voxel51/__init__.py
+++ b/voxel51/__init__.py
@@ -3,3 +3,24 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 '''
+# pragma pylint: disable=redefined-builtin
+# pragma pylint: disable=unused-wildcard-import
+# pragma pylint: disable=wildcard-import
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import *
+# pragma pylint: enable=redefined-builtin
+# pragma pylint: enable=unused-wildcard-import
+# pragma pylint: enable=wildcard-import
+
+from pkgutil import extend_path
+
+#
+# This statement allows multiple `voxel51.XXX` packages to be installed in the
+# same environment and used simultaneously.
+#
+# https://docs.python.org/2/library/pkgutil.html#pkgutil.extend_path
+#
+__path__ = extend_path(__path__, __name__)

--- a/voxel51/apps/auth.py
+++ b/voxel51/apps/auth.py
@@ -20,8 +20,8 @@ from builtins import *
 import logging
 import os
 
-from voxel51.auth import Token, TokenLoadError
-import voxel51.utils as voxu
+from voxel51.users.auth import Token
+import voxel51.users.utils as voxu
 
 
 logger = logging.getLogger(__name__)
@@ -65,8 +65,8 @@ def load_application_token(token_path=None):
     '''Loads the active application token.
 
     Args:
-        token_path: an optional path to an :class:`ApplicationToken` JSON file.
-            If no path is provided, the ``VOXEL51_APP_TOKEN`` environment
+        token_path (str, optional): a path to an :class:`ApplicationToken` JSON
+            file. If no path is provided, the ``VOXEL51_APP_TOKEN`` environment
             variable is checked and, if set, the token is loaded from that
             path. Otherwise, the token is loaded from
             ``~/.voxel51/app-token.json``
@@ -75,13 +75,13 @@ def load_application_token(token_path=None):
         an :class:`ApplicationToken` instance
 
     Raises:
-        voxel51.auth.TokenLoadError: if no valid token was found
+        :class:`ApplicationTokenLoadError` if no valid token was found
     '''
     path = token_path or os.environ.get(TOKEN_ENVIRON_VAR) or TOKEN_PATH
     try:
         return ApplicationToken.from_json(path)
     except IOError:
-        raise TokenLoadError("No application token found")
+        raise ApplicationTokenLoadError("No application token found")
 
 
 class ApplicationToken(Token):
@@ -92,8 +92,8 @@ class ApplicationToken(Token):
         this application token.
 
         Args:
-            username: an optional username for which the requests are being
-                performed. By default, no username is included
+            username (str, optional): a username for which the requests are
+                being performed. By default, no username is included
 
         Returns:
             a header dictionary
@@ -102,3 +102,8 @@ class ApplicationToken(Token):
         if username:
             header[USER_HEADER] = username
         return header
+
+
+class ApplicationTokenLoadError(Exception):
+    '''Exception raised when a :class:`ApplicationToken` fails to load.'''
+    pass

--- a/voxel51/users/__init__.py
+++ b/voxel51/users/__init__.py
@@ -1,0 +1,5 @@
+'''
+| Copyright 2017-2019, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+'''

--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -20,7 +20,7 @@ from builtins import *
 import logging
 import os
 
-import voxel51.utils as voxu
+import voxel51.users.utils as voxu
 
 
 logger = logging.getLogger(__name__)
@@ -40,7 +40,7 @@ def activate_token(path):
     authentication.
 
     Args:
-        path (str): the path to an API token JSON file
+        path (str): the path to a :class:`Token` JSON file
     '''
     voxu.copy_file(path, TOKEN_PATH)
     logger.info("Token successfully activated")
@@ -62,17 +62,17 @@ def load_token(token_path=None):
     '''Loads the active API token.
 
     Args:
-        token_path: an optional path to a valid Token JSON file. If no path is
-            provided as an argument, the ``VOXEL51_API_TOKEN`` environment
+        token_path (str, optional): the path to a valid :class:`Token` JSON
+            file. If no path is provided, the ``VOXEL51_API_TOKEN`` environment
             variable is checked and, if set, the token is loaded from that
             path. Otherwise, the token is loaded from
             ``~/.voxel51/api-token.json``
 
     Returns:
-        a Token instance
+        a :class:`Token` instance
 
     Raises:
-        TokenLoadError if no valid token was found
+        :class:`TokenLoadError` if no valid token was found
     '''
     path = token_path or os.environ.get(TOKEN_ENVIRON_VAR) or TOKEN_PATH
     try:
@@ -119,5 +119,5 @@ class Token(object):
 
 
 class TokenLoadError(Exception):
-    '''Exception raised when a Token fails to load.'''
+    '''Exception raised when a :class:`Token` fails to load.'''
     pass

--- a/voxel51/users/jobs.py
+++ b/voxel51/users/jobs.py
@@ -20,7 +20,7 @@ from future.utils import iteritems
 
 from collections import OrderedDict
 
-import voxel51.utils as voxu
+import voxel51.users.utils as voxu
 
 
 DATA_ID_FIELD = "data-id"
@@ -66,8 +66,8 @@ class JobRequest(voxu.Serializable):
         analytic (str): the name of the analytic to run
         version (str): the version of the analytic to run
         compute_mode (JobComputeMode): the compute mode for the job
-        inputs (dict): a dictionary mapping input names to RemoteDataPath
-            instances
+        inputs (dict): a dictionary mapping input names to
+            :class:`voxel51.users.utils.RemoteDataPath` instances
         parameters (dict): a dictionary mapping parameter names to values
     '''
 
@@ -90,30 +90,35 @@ class JobRequest(voxu.Serializable):
     def set_input(self, name, path=None, **kwargs):
         '''Sets the input of the given name.
 
-        The input value can be specified either as a RemoteDataPath instance
-        or as valid keyword arguments to construct one.
+        The input value can be specified either as a
+        :class:`voxel51.users.utils.RemoteDataPath` instance or as valid
+        keyword arguments to construct one.
 
         Args:
             name (str): the input name to set
-            path (RemoteDataPath, optional): a RemoteDataPath instance. If not
+            path (RemoteDataPath, optional): a
+                :class:`voxel51.users.utils.RemoteDataPath` instance. If not
                 specified, valid kwargs must be provided
-            **kwargs: valid argument(s) for RemoteDataPath()
+            **kwargs: valid constructor argument(s) for
+                :class:`voxel51.users.utils.RemoteDataPath`
         '''
         self.inputs[name] = path or RemoteDataPath(**kwargs)
 
     def set_data_parameter(self, name, path=None, **kwargs):
         '''Sets the data parameter of the given name.
 
-        Data parameters are parameters that are defined by a RemoteDataPath
-        instance and are read from cloud storage at runtime by the job. The
-        parameter can be specified either as a RemoteDataPath instance or as
+        Data parameters are parameters that are defined by a
+        :class:`voxel51.users.utils.RemoteDataPath` instance and are read from
+        cloud storage at runtime by the job. The parameter can be specified
+        either as a :class:`voxel51.users.utils.RemoteDataPath` instance or as
         valid keyword arguments to construct one.
 
         Args:
             name (str): the input name to set
             path (RemoteDataPath, optional): a RemoteDataPath instance. If not
                 specified, valid kwargs must be provided
-            **kwargs: valid argument(s) for RemoteDataPath()
+            **kwargs: valid constructor argument(s) for
+                :class:`voxel51.users.utils.RemoteDataPath`
         '''
         self.parameters[name] = path or RemoteDataPath(**kwargs)
 
@@ -186,7 +191,7 @@ class RemoteDataPath(voxu.Serializable):
             data_id (str): the ID of the data in cloud storage
 
         Raises:
-            RemoteDataPathError if the instance creation failed
+            :class:`RemoteDataPathError` if the instance creation failed
         '''
         self.data_id = data_id
         if not self.is_valid:
@@ -233,7 +238,7 @@ class RemoteDataPath(voxu.Serializable):
 
         Returns:
             True if val is a valid RemoteDataPath JSON dictionary, and False
-                otherwise
+            otherwise
         '''
         try:
             RemoteDataPath.from_dict(val)
@@ -252,7 +257,7 @@ class RemoteDataPath(voxu.Serializable):
             a RemoteDataPath instance
 
         Raises:
-            RemoteDataPathError if the instance creation failed
+            :class:`RemoteDataPathError` if the instance creation failed
         '''
         if DATA_ID_FIELD in d:
             return cls.from_data_id(d[DATA_ID_FIELD])
@@ -265,5 +270,7 @@ class RemoteDataPath(voxu.Serializable):
 
 
 class RemoteDataPathError(Exception):
-    '''Error raised when an invalid RemoteDataPath instance is found.'''
+    '''Error raised when an invalid :class:`RemoteDataPath` instance is
+    found.
+    '''
     pass

--- a/voxel51/users/query.py
+++ b/voxel51/users/query.py
@@ -55,7 +55,7 @@ class BaseQuery(object):
             field (str): a query field to add
 
         Returns:
-            the updated BaseQuery instance
+            the updated query instance
         '''
         if self._is_supported_field(field):
             self.fields.append(field)
@@ -68,7 +68,7 @@ class BaseQuery(object):
             field (list): a list of query fields to add
 
         Returns:
-            the updated BaseQuery instance
+            the updated query instance
         '''
         for field in fields:
             self.add_field(field)
@@ -78,7 +78,7 @@ class BaseQuery(object):
         '''Adds all supported fields to the query.
 
         Returns:
-            the updated BaseQuery instance
+            the updated query instance
         '''
         self.add_fields(self._supported_fields)
         return self
@@ -91,7 +91,7 @@ class BaseQuery(object):
             search_str (str): the search string
 
         Returns:
-            the updated BaseQuery instance
+            the updated query instance
         '''
         if self._is_supported_field(field):
             self.search.append("%s:%s" % (field, search_str))
@@ -105,7 +105,7 @@ class BaseQuery(object):
             descending (bool, optional): whether to sort in descending order
 
         Returns:
-            the updated BaseQuery instance
+            the updated query instance
         '''
         if self._is_supported_field(field):
             self.sort = "%s:%s" % (field, "desc" if descending else "asc")
@@ -118,7 +118,7 @@ class BaseQuery(object):
             offset (int): the desired record offset
 
         Returns:
-            the updated BaseQuery instance
+            the updated query instance
         '''
         if isinstance(offset, int) and offset >= 0:
             self.offset = offset
@@ -131,7 +131,7 @@ class BaseQuery(object):
             limit (int): the desired record limit
 
         Returns:
-            the updated BaseQuery instance
+            the updated query instance
         '''
         if isinstance(limit, int) and limit > 0:
             self.limit = limit
@@ -197,7 +197,7 @@ class AnalyticsQuery(BaseQuery):
                 analytic in the query
 
         Returns:
-            the updated AnalyticsQuery instance
+            the updated query instance
         '''
         self.all_versions = all_versions
         return self

--- a/voxel51/users/utils.py
+++ b/voxel51/users/utils.py
@@ -187,7 +187,7 @@ class Serializable(object):
 
         Returns:
             a dictionary mapping attribute names to field names (as they
-                should appear in the JSON file)
+            should appear in the JSON file)
         '''
         return {a: a for a in vars(self) if not a.startswith("_")}
 


### PR DESCRIPTION
The whole point of this PR is to enable the following two lines in `voxel51/__init__.py`:

```
from pkgutil import extend_path

#
# This statement allows multiple `voxel51.XXX` packages to be installed in the
# same environment and used simultaneously.
#
# https://docs.python.org/2/library/pkgutil.html#pkgutil.extend_path
#
__path__ = extend_path(__path__, __name__)
```

This is required in order to install both `api-py` and `platform-sdk` in the same virtual environment, which is a very reasonable thing to want to do.

It is also cleaner this way, because all platform user-facing code is clearly organized under the `users/` package.