### PR TITLE
Fix large image/data file uploads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ future==0.16.0
 idna==2.6
 m2r==0.2.1
 requests==2.20.0
+requests-toolbelt==0.9.1
 Sphinx==1.7.5
 sphinx-rtd-theme==0.2.4
 sphinxcontrib-napoleon==0.6.1

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -209,8 +209,9 @@ class ApplicationAPI(API):
         mime_type = _get_mime_type(image_tar_path)
         with open(image_tar_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
-            res = voxu.upload_files(self._requests, endpoint, files,
-                headers=self._header, params=params)
+            res = voxu.upload_files(
+                self._requests, endpoint, files, headers=self._header,
+                params=params)
         _validate_response(res)
 
     def delete_analytic(self, analytic_id):

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -209,8 +209,8 @@ class ApplicationAPI(API):
         mime_type = _get_mime_type(image_tar_path)
         with open(image_tar_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
-            res = self._requests.post(
-                endpoint, headers=self._header, files=files, params=params)
+            res = voxu.upload_files(self._requests, endpoint, files,
+                headers=self._header, params=params)
         _validate_response(res)
 
     def delete_analytic(self, analytic_id):

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -23,6 +23,7 @@ import time
 
 import mimetypes
 import requests
+from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 import voxel51.users.auth as voxa
 import voxel51.users.jobs as voxj
@@ -197,9 +198,11 @@ class API(object):
         filename = os.path.basename(image_tar_path)
         mime_type = _get_mime_type(image_tar_path)
         with open(image_tar_path, "rb") as df:
-            files = {"file": (filename, df, mime_type)}
+            data = MultipartEncoder({"file": (filename, df, mime_type)})
+            file_headers = self._header.copy()
+            file_headers["Content-Type"] = data.content_type
             res = self._requests.post(
-                endpoint, headers=self._header, files=files, params=params)
+                endpoint, headers=file_headers, data=data, params=params)
         _validate_response(res)
 
     def delete_analytic(self, analytic_id):

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -198,8 +198,9 @@ class API(object):
         mime_type = _get_mime_type(image_tar_path)
         with open(image_tar_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
-            res = voxu.upload_files(self._requests, endpoint, files,
-                headers=self._header, params=params)
+            res = voxu.upload_files(
+                self._requests, endpoint, files, headers=self._header,
+                params=params)
         _validate_response(res)
 
     def delete_analytic(self, analytic_id):
@@ -276,8 +277,8 @@ class API(object):
                 if isinstance(ttl, datetime):
                     ttl = ttl.isoformat()
                 files["data_ttl"] = (None, str(ttl))
-            res = voxu.upload_files(self._requests, endpoint, files,
-                headers=self._header)
+            res = voxu.upload_files(
+                self._requests, endpoint, files, headers=self._header)
 
         _validate_response(res)
         return _parse_json_response(res)["data"]

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -23,7 +23,6 @@ import time
 
 import mimetypes
 import requests
-from requests_toolbelt.multipart.encoder import MultipartEncoder
 
 import voxel51.users.auth as voxa
 import voxel51.users.jobs as voxj
@@ -198,11 +197,9 @@ class API(object):
         filename = os.path.basename(image_tar_path)
         mime_type = _get_mime_type(image_tar_path)
         with open(image_tar_path, "rb") as df:
-            data = MultipartEncoder({"file": (filename, df, mime_type)})
-            file_headers = self._header.copy()
-            file_headers["Content-Type"] = data.content_type
-            res = self._requests.post(
-                endpoint, headers=file_headers, data=data, params=params)
+            files = {"file": (filename, df, mime_type)}
+            res = voxu.upload_files(self._requests, endpoint, files,
+                headers=self._header, params=params)
         _validate_response(res)
 
     def delete_analytic(self, analytic_id):
@@ -279,8 +276,8 @@ class API(object):
                 if isinstance(ttl, datetime):
                     ttl = ttl.isoformat()
                 files["data_ttl"] = (None, str(ttl))
-            res = self._requests.post(
-                endpoint, files=files, headers=self._header)
+            res = voxu.upload_files(self._requests, endpoint, files,
+                headers=self._header)
 
         _validate_response(res)
         return _parse_json_response(res)["data"]

--- a/voxel51/users/utils.py
+++ b/voxel51/users/utils.py
@@ -23,6 +23,8 @@ import logging
 import os
 import shutil
 
+from requests_toolbelt.multipart.encoder import MultipartEncoder
+
 
 logger = logging.getLogger(__name__)
 
@@ -200,3 +202,26 @@ def _recurse(v):
     elif isinstance(v, Serializable):
         return v.to_dict()
     return v
+
+
+def upload_files(requests, url, files, headers, **kwargs):
+    '''Upload one or more files using a streaming upload.
+
+    This supports files larger than 2GB.
+
+    Args:
+        requests (requests|requests.Session): an existing session to use, or
+            the ``requests`` module
+        url (str): the request endpoint
+        files (dict): files to upload, in the same format as the ``files``
+            argument to ``requests``
+        headers (dict): headers to include
+        kwargs: any other arguments to pass to ``requests``
+
+    Returns:
+        a ``requests.Response``
+    '''
+    data = MultipartEncoder(files)
+    headers = headers.copy()
+    headers["Content-Type"] = data.content_type
+    return requests.post(url, headers=headers, data=data, **kwargs)

--- a/voxel51/users/utils.py
+++ b/voxel51/users/utils.py
@@ -205,9 +205,10 @@ def _recurse(v):
 
 
 def upload_files(requests, url, files, headers, **kwargs):
-    '''Upload one or more files using a streaming upload.
+    '''Upload one or more files of any size using a streaming upload.
 
-    This supports files larger than 2GB.
+    This is intended as an alternative to using ``requests`` directly for files
+    larger than 2GB.
 
     Args:
         requests (requests|requests.Session): an existing session to use, or
@@ -221,7 +222,10 @@ def upload_files(requests, url, files, headers, **kwargs):
     Returns:
         a ``requests.Response``
     '''
+    # note: this is limited to 8K chunk size. If this becomes an issue,
+    # monkey-patching data.read to ignore the given chunk size is an option.
     data = MultipartEncoder(files)
+    # add the necessary content-type without modifying the original headers
     headers = headers.copy()
     headers["Content-Type"] = data.content_type
     return requests.post(url, headers=headers, data=data, **kwargs)


### PR DESCRIPTION
Fixes #42. Tested under Python 2/3 with various file sizes in the 50MB-3GB range.

Note that `http.client` has a hardcoded 8192 block size for reading files that apparently affects upload speed for `requests_toolbelt` as well. I was unable to see a significant difference with and without this change, but it's possible that this change would be slower with a faster upstream connection. If that's a concern, I can look into workarounds.