### PR TITLE
Add support for "or" search queries

### DIFF
--- a/voxel51/users/query.py
+++ b/voxel51/users/query.py
@@ -97,6 +97,18 @@ class BaseQuery(object):
             self.search.append("%s:%s" % (field, search_str))
         return self
 
+    def add_search_or(self, field, search_strs):
+        '''Adds the given "OR" search to the query.
+
+        Args:
+            field (str): the query field on which to search
+            search_strs (list): a list of search strings to form an "or" query
+
+        Returns:
+            the updated query instance
+        '''
+        return self.add_search(field, "|".join(search_strs))
+
     def sort_by(self, field, descending=True):
         '''Adds the given search to the query.
 

--- a/voxel51/users/query.py
+++ b/voxel51/users/query.py
@@ -86,6 +86,9 @@ class BaseQuery(object):
     def add_search(self, field, search_str):
         '''Adds the given search to the query.
 
+        The resulting query will return results where the specified field
+        matches the specified search string.
+
         Args:
             field (str): the query field on which to search
             search_str (str): the search string
@@ -99,6 +102,9 @@ class BaseQuery(object):
 
     def add_search_or(self, field, search_strs):
         '''Adds the given "OR" search to the query.
+
+        The resulting query will return results where the specified field
+        matches any of the specified search strings.
 
         Args:
             field (str): the query field on which to search


### PR DESCRIPTION
I avoided changing `add_search` in case other types of queries are eventually supported.