### PR TITLE
Adding support for uploading Image-To-Video analytics

### DIFF
--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -17,9 +17,8 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
-import json
-
-import requests
+import mimetypes
+import os
 
 from voxel51.users.api import API, APIError
 import voxel51.apps.auth as voxa
@@ -186,7 +185,7 @@ class ApplicationAPI(API):
         with open(doc_json_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
             if is_image_to_video:
-                files["is_image_to_video"] = (None, str(is_image_to_video)
+                files["is_image_to_video"] = (None, str(is_image_to_video))
             res = self._requests.post(
                 endpoint, headers=self._header, files=files)
         _validate_response(res)
@@ -333,6 +332,10 @@ class ApplicationAPI(API):
 class ApplicationAPIError(APIError):
     '''Exception raised when an :class:`ApplicationAPI` request fails.'''
     pass
+
+
+def _get_mime_type(path):
+    return mimetypes.guess_type(path)[0] or "application/octet-stream"
 
 
 def _validate_response(res):

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -161,7 +161,7 @@ class ApplicationAPI(API):
         _validate_response(res)
         return _parse_json_response(res)
 
-    def upload_analytic(self, doc_json_path):
+    def upload_analytic(self, doc_json_path, is_image_to_video=False):
         '''Uploads the analytic documentation JSON file that describes a new
         analytic to deploy.
 
@@ -170,6 +170,9 @@ class ApplicationAPI(API):
 
         Args:
             doc_json_path (str): the path to the analytic JSON
+            is_image_to_video (bool, optional): whether the analytic that you
+                are uploading is a image-based model for use with the
+                Image-To-Video tool
 
         Returns:
             a dictionary containing metadata about the posted analytic
@@ -182,6 +185,8 @@ class ApplicationAPI(API):
         mime_type = _get_mime_type(doc_json_path)
         with open(doc_json_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
+            if is_image_to_video:
+                files["is_image_to_video"] = (None, str(is_image_to_video)
             res = self._requests.post(
                 endpoint, headers=self._header, files=files)
         _validate_response(res)

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -170,7 +170,7 @@ class ApplicationAPI(API):
         Args:
             doc_json_path (str): the path to the analytic JSON
             is_image_to_video (bool, optional): whether the analytic that you
-                are uploading is a image-based model for use with the
+                are uploading is an image-based model for use with the
                 Image-To-Video tool
 
         Returns:

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -160,7 +160,7 @@ class ApplicationAPI(API):
         _validate_response(res)
         return _parse_json_response(res)
 
-    def upload_analytic(self, doc_json_path, is_image_to_video=False):
+    def upload_analytic(self, doc_json_path, analytic_type=None):
         '''Uploads the analytic documentation JSON file that describes a new
         analytic to deploy.
 
@@ -169,9 +169,9 @@ class ApplicationAPI(API):
 
         Args:
             doc_json_path (str): the path to the analytic JSON
-            is_image_to_video (bool, optional): whether the analytic that you
-                are uploading is an image-based model for use with the
-                Image-To-Video tool
+            analytic_type (AnalyticType, optional): the type of analytic that
+                you are uploading. If not specified, it is assumed that you
+                are uploading a standard platform analytic
 
         Returns:
             a dictionary containing metadata about the posted analytic
@@ -184,8 +184,8 @@ class ApplicationAPI(API):
         mime_type = _get_mime_type(doc_json_path)
         with open(doc_json_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
-            if is_image_to_video:
-                files["is_image_to_video"] = (None, str(is_image_to_video))
+            if analytic_type:
+                files["analytic_type"] = (None, str(analytic_type))
             res = self._requests.post(
                 endpoint, headers=self._header, files=files)
         _validate_response(res)

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -33,6 +33,13 @@ _BASE_API_URL = "https://api.voxel51.com/v1"
 _CHUNK_SIZE = 32 * 1024 * 1024  # in bytes
 
 
+class AnalyticType(object):
+    '''Enum describing the possible types of analytics.'''
+
+    PLATFORM = "PLATFORM"
+    IMAGE_TO_VIDEO = "IMAGE_TO_VIDEO"
+
+
 class API(object):
     '''Main class for managing a session with the Voxel51 Platform API.
 
@@ -149,7 +156,7 @@ class API(object):
         _validate_response(res)
         return _parse_json_response(res)
 
-    def upload_analytic(self, doc_json_path, is_image_to_video=False):
+    def upload_analytic(self, doc_json_path, analytic_type=None):
         '''Uploads the analytic documentation JSON file that describes a new
         analytic to deploy.
 
@@ -158,9 +165,9 @@ class API(object):
 
         Args:
             doc_json_path (str): the path to the analytic JSON
-            is_image_to_video (bool, optional): whether the analytic that you
-                are uploading is an image-based model for use with the
-                Image-To-Video tool
+            analytic_type (AnalyticType, optional): the type of analytic that
+                you are uploading. If not specified, it is assumed that you
+                are uploading a standard platform analytic
 
         Returns:
             a dictionary containing metadata about the posted analytic
@@ -173,8 +180,8 @@ class API(object):
         mime_type = _get_mime_type(doc_json_path)
         with open(doc_json_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
-            if is_image_to_video:
-                files["is_image_to_video"] = (None, str(is_image_to_video))
+            if analytic_type:
+                files["analytic_type"] = (None, str(analytic_type))
             res = self._requests.post(
                 endpoint, headers=self._header, files=files)
         _validate_response(res)

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -159,7 +159,7 @@ class API(object):
         Args:
             doc_json_path (str): the path to the analytic JSON
             is_image_to_video (bool, optional): whether the analytic that you
-                are uploading is a image-based model for use with the
+                are uploading is an image-based model for use with the
                 Image-To-Video tool
 
         Returns:

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -174,7 +174,7 @@ class API(object):
         with open(doc_json_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
             if is_image_to_video:
-                files["is_image_to_video"] = (None, str(is_image_to_video)
+                files["is_image_to_video"] = (None, str(is_image_to_video))
             res = self._requests.post(
                 endpoint, headers=self._header, files=files)
         _validate_response(res)

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -149,7 +149,7 @@ class API(object):
         _validate_response(res)
         return _parse_json_response(res)
 
-    def upload_analytic(self, doc_json_path):
+    def upload_analytic(self, doc_json_path, is_image_to_video=False):
         '''Uploads the analytic documentation JSON file that describes a new
         analytic to deploy.
 
@@ -158,6 +158,9 @@ class API(object):
 
         Args:
             doc_json_path (str): the path to the analytic JSON
+            is_image_to_video (bool, optional): whether the analytic that you
+                are uploading is a image-based model for use with the
+                Image-To-Video tool
 
         Returns:
             a dictionary containing metadata about the posted analytic
@@ -170,6 +173,8 @@ class API(object):
         mime_type = _get_mime_type(doc_json_path)
         with open(doc_json_path, "rb") as df:
             files = {"file": (filename, df, mime_type)}
+            if is_image_to_video:
+                files["is_image_to_video"] = (None, str(is_image_to_video)
             res = self._requests.post(
                 endpoint, headers=self._header, files=files)
         _validate_response(res)


### PR DESCRIPTION
Added an optional `analytic_type` field to specify that an analytic is an image-to-video analytic