### PR TITLE
Add thread pool wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,33 @@ api.upload_job_request(job_request, "<job-name>", auto_start=True)
 ```
 
 
+## Improving Request Efficiency
+
+A common pattern when interacting with the platform is to perform an operation
+to a list of data or jobs. In such cases, you can dramatically increase the
+efficiency of your code by using multiple threads. This library exposes a
+thread pool that provides an easy way to distribute work among multiple
+threads.
+
+For example, the following code will start all unstarted jobs on the platform
+and wait for all requests to complete:
+
+```py
+from voxel51.users.api import API
+from voxel51.users.jobs import JobState
+from voxel51.users.query import JobsQuery
+
+api = API()
+jobs_query = JobsQuery().add_fields(["id", "state"])
+jobs = api.query_jobs(jobs_query)["jobs"]
+
+api.thread_map(api.start_job,
+    [job["id"] for job in jobs if job["state"] == JobState.READY])
+
+```
+
+See :func:`voxel51.users.api.API.thread_map` for details.
+
 ## Generating Documentation
 
 This project uses

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 certifi==2018.1.18
 chardet==3.0.4
 future==0.16.0
+futures==3.3.0; python_version == "2.7"
 idna==2.6
 m2r==0.2.1
 requests==2.20.0

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -17,6 +17,7 @@ from builtins import *
 # pragma pylint: enable=unused-wildcard-import
 # pragma pylint: enable=wildcard-import
 
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 import os
 import time
@@ -95,6 +96,9 @@ class API(object):
         '''
         token = voxa.load_token(token_path=token_path)
         return cls(token=token)
+
+    def thread_pool(self, max_workers=5):
+        return ThreadPoolExecutor(max_workers)
 
     # ANALYTICS ###############################################################
 

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -105,7 +105,9 @@ class API(object):
             callback (function): the function to call on each list item
             items (list): a list of arguments to pass to the callback (each
                 item in this list corresponds to a separate call)
-            max_workers (int, optional): the number of calls to run in parallel
+            max_workers (int, optional): the number of calls to run in
+                parallel. Passing `None` will compute this based on the number
+                of available CPUs.
             generator (bool): if true, return a generator instead of a list
 
         Returns:

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -97,7 +97,7 @@ class API(object):
         token = voxa.load_token(token_path=token_path)
         return cls(token=token)
 
-    def thread_map(self, callback, items, max_workers=5):
+    def thread_map(self, callback, items, max_workers=5, generator=False):
         '''Makes parallel calls to a callback with arguments taken from a list.
 
         Args:
@@ -105,13 +105,17 @@ class API(object):
             items (list): a list of arguments to pass to the callback (each
                 item in this list corresponds to a separate call)
             max_workers (int, optional): the number of calls to run in parallel
+            generator (bool): if true, return a generator instead of a list
 
         Returns:
             a generator of values returned by `callback`, in the same order as
             `items` (to obtain a list of return values, or to wait for all
             calls to complete, wrap the returned generator with `list()`)
         '''
-        return ThreadPoolExecutor(max_workers).map(callback, items)
+        gen = ThreadPoolExecutor(max_workers).map(callback, items)
+        if generator:
+            return gen
+        return list(gen)
 
     # ANALYTICS ###############################################################
 

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -98,27 +98,25 @@ class API(object):
         return cls(token=token)
 
     @staticmethod
-    def thread_map(callback, items, max_workers=5, generator=False):
-        '''Makes parallel calls to a callback with arguments taken from a list.
+    def thread_map(callback, iterable, max_workers=None):
+        '''Applies the callback function to each item in the iterable using a
+        pool of parallel worker threads.
 
         Args:
             callback (function): the function to call on each list item
-            items (list): a list of arguments to pass to the callback (each
-                item in this list corresponds to a separate call)
-            max_workers (int, optional): the number of calls to run in
-                parallel. Passing `None` will compute this based on the number
-                of available CPUs.
-            generator (bool): if true, return a generator instead of a list
+            iterable (iterable): an iterable of arguments to pass to the
+                callback
+            max_workers (int, optional): the number of worker threads to use.
+                The default is `None`, which uses a handful of threads for each
+                CPU on your machine. See the documentation for the
+                `concurrent.futures.ThreadPoolExecutor` method for more details
 
         Returns:
-            a generator of values returned by `callback`, in the same order as
-            `items` (to obtain a list of return values, or to wait for all
-            calls to complete, wrap the returned generator with `list()`)
+            a list of values returned by `callback`, in the same order as the
+            input `iterable`
         '''
-        gen = ThreadPoolExecutor(max_workers).map(callback, items)
-        if generator:
-            return gen
-        return list(gen)
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            return list(executor.map(callback, iterable))
 
     # ANALYTICS ###############################################################
 

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -97,8 +97,21 @@ class API(object):
         token = voxa.load_token(token_path=token_path)
         return cls(token=token)
 
-    def thread_pool(self, max_workers=5):
-        return ThreadPoolExecutor(max_workers)
+    def thread_map(self, callback, items, max_workers=5):
+        '''Makes parallel calls to a callback with arguments taken from a list.
+
+        Args:
+            callback (function): the function to call on each list item
+            items (list): a list of arguments to pass to the callback (each
+                item in this list corresponds to a separate call)
+            max_workers (int, optional): the number of calls to run in parallel
+
+        Returns:
+            a generator of values returned by `callback`, in the same order as
+            `items` (to obtain a list of return values, or to wait for all
+            calls to complete, wrap the returned generator with `list()`)
+        '''
+        return ThreadPoolExecutor(max_workers).map(callback, items)
 
     # ANALYTICS ###############################################################
 

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -97,7 +97,8 @@ class API(object):
         token = voxa.load_token(token_path=token_path)
         return cls(token=token)
 
-    def thread_map(self, callback, items, max_workers=5, generator=False):
+    @staticmethod
+    def thread_map(callback, items, max_workers=5, generator=False):
         '''Makes parallel calls to a callback with arguments taken from a list.
 
         Args:


### PR DESCRIPTION
Per discussion in #51, we might want a way to perform tasks that involve multiple API requests in parallel. #51's approach didn't make that easier, so this is a very small PR that makes a ThreadPoolExecutor available (across Python versions) and allows things like this (pseudocode):

```python
api = API()

def run_job(data):
  data_id = api.upload_data(data)
  job_id = api.run_job(data_id)
  return job_id

job_ids = list(api.thread_map(run_job, data_files))
```

By default, at most 5 calls to `run_job` would be active at a time, but this is adjustable.

Alternatively, `thread_pool().map()` could be abstracted away - [Executor](https://docs.python.org/dev/library/concurrent.futures.html#concurrent.futures.Executor) doesn't provide much else that would be useful in this case.