### PR TITLE
Fix default filename when downloading data

### DIFF
--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -369,7 +369,7 @@ class API(object):
             :class:`APIError` if the request was unsuccessful
         '''
         if not output_path:
-            output_path = self.get_data_details(data_id)["filename"]
+            output_path = self.get_data_details(data_id)["name"]
 
         endpoint = self.base_url + "/data/" + data_id + "/download"
         self._stream_download(endpoint, output_path)


### PR DESCRIPTION
The key returned by the API is `name`, not `filename`
See also https://voxel51.com/docs/api/?python#data-get-data-details