### PR TITLE
Handle download errors before saving files to disk

### DIFF
--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -781,10 +781,10 @@ class API(object):
     def _stream_download(self, url, output_path):
         voxu.ensure_basedir(output_path)
         with self._requests.get(url, headers=self._header, stream=True) as res:
+            _validate_response(res)
             with open(output_path, "wb") as f:
                 for chunk in res.iter_content(chunk_size=_CHUNK_SIZE):
                     f.write(chunk)
-            _validate_response(res)
 
 
 class APIError(Exception):


### PR DESCRIPTION
Parsing errors needs to be done before reading the response - if handled after, the error message itself is written to disk, and then the exception doesn't have the message returned from the API (e.g. 400s will just report `voxel51.users.api.APIError: 400: Bad Request for URL`) because the response body can only be read once. (`_validate_response` only reads the status code for successful requests, so downloading data that exists still works.)