### PR TITLE
Parsing base API URL from token, if possible

### DIFF
--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -119,7 +119,7 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/analytics/list"
+        endpoint = voxu.urljoin(self.base_url, "apps", "analytics", "list")
         data = {"all_versions": all_versions}
         res = self._requests.get(endpoint, headers=self._header, json=data)
         _validate_response(res)
@@ -140,7 +140,7 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/analytics"
+        endpoint = voxu.urljoin(self.base_url, "apps", "analytics")
         res = self._requests.get(
             endpoint, headers=self._header, params=analytics_query.to_dict())
         _validate_response(res)
@@ -158,7 +158,8 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/analytics/" + analytic_id
+        endpoint = voxu.urljoin(
+            self.base_url, "apps", "analytics", analytic_id)
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)
@@ -182,7 +183,7 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/analytics"
+        endpoint = voxu.urljoin(self.base_url, "apps", "analytics")
         filename = os.path.basename(doc_json_path)
         mime_type = _get_mime_type(doc_json_path)
         with open(doc_json_path, "rb") as df:
@@ -210,7 +211,8 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/analytics/" + analytic_id + "/images"
+        endpoint = voxu.urljoin(
+            self.base_url, "apps", "analytics", analytic_id, "images")
         params = {"type": image_type.lower()}
         filename = os.path.basename(image_tar_path)
         mime_type = _get_mime_type(image_tar_path)
@@ -231,7 +233,8 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/analytics/" + analytic_id
+        endpoint = voxu.urljoin(
+            self.base_url, "apps", "analytics", analytic_id)
         res = self._requests.delete(endpoint, headers=self._header)
         _validate_response(res)
 
@@ -254,7 +257,7 @@ class ApplicationAPI(API):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/data"
+        endpoint = voxu.urljoin(self.base_url, "apps", "data")
         res = self._requests.get(
             endpoint, headers=self._header, params=data_query.to_dict())
         _validate_response(res)
@@ -279,7 +282,7 @@ class ApplicationAPI(API):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/jobs"
+        endpoint = voxu.urljoin(self.base_url, "apps", "jobs")
         res = self._requests.get(
             endpoint, headers=self._header, params=jobs_query.to_dict())
         _validate_response(res)
@@ -296,7 +299,7 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/users"
+        endpoint = voxu.urljoin(self.base_url, "apps", "users")
         data = {"username": username}
         res = self._requests.post(endpoint, headers=self._header, json=data)
         _validate_response(res)
@@ -310,7 +313,7 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/users/list"
+        endpoint = voxu.urljoin(self.base_url, "apps", "users", "list")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["users"]
@@ -326,7 +329,7 @@ class ApplicationAPI(API):
         Raises:
             :class:`ApplicationAPIError`: if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/apps/status/all"
+        endpoint = voxu.urljoin(self.base_url, "apps", "status", "all")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["statuses"]

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -59,6 +59,7 @@ class ApplicationAPI(API):
         '''
         if token is None:
             token = voxa.load_application_token()
+
         super(ApplicationAPI, self).__init__(
             token=token, keep_alive=keep_alive)
         self.active_user = None
@@ -80,19 +81,21 @@ class ApplicationAPI(API):
         self._header = self.token.get_header()
 
     @classmethod
-    def from_json(cls, token_path):
+    def from_json(cls, token_path, **kwargs):
         '''Creates an :class:`ApplicationAPI` instance from the given
         :class:`ApplicationToken` JSON file.
 
         Args:
             token_path (str): the path to an
                 :class:`voxel51.apps.auth.ApplicationToken` JSON file
+            **kwargs (dict): optional keyword arguments for
+                `ApplicationAPI(token=token, **kwargs)`
 
         Returns:
             an :class:`ApplicationAPI` instance
         '''
         token = voxa.load_application_token(token_path=token_path)
-        return cls(token=token)
+        return cls(token=token, **kwargs)
 
     #
     # ANALYTICS ###############################################################

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1117,6 +1117,7 @@ def _print_active_token_info():
     contents = [
         ("id", token.id),
         ("creation date", _render_datetime(token.creation_date)),
+        ("base API URL", token.base_api_url),
         ("path", token_path),
     ]
     table_str = tabulate(

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -139,7 +139,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/analytics/list"
+        endpoint = voxu.urljoin(self.base_url, "analytics", "list")
         data = {"all_versions": all_versions}
         res = self._requests.get(endpoint, headers=self._header, json=data)
         _validate_response(res)
@@ -160,7 +160,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/analytics"
+        endpoint = voxu.urljoin(self.base_url, "analytics")
         res = self._requests.get(
             endpoint, headers=self._header, params=analytics_query.to_dict())
         _validate_response(res)
@@ -178,7 +178,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/analytics/" + analytic_id
+        endpoint = voxu.urljoin(self.base_url, "analytics", analytic_id)
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)
@@ -202,7 +202,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/analytics"
+        endpoint = voxu.urljoin(self.base_url, "analytics")
         filename = os.path.basename(doc_json_path)
         mime_type = _get_mime_type(doc_json_path)
         with open(doc_json_path, "rb") as df:
@@ -231,7 +231,8 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/analytics/" + analytic_id + "/images"
+        endpoint = voxu.urljoin(
+            self.base_url, "analytics", analytic_id, "images")
         params = {"type": image_type.lower()}
         filename = os.path.basename(image_tar_path)
         mime_type = _get_mime_type(image_tar_path)
@@ -252,7 +253,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/analytics/" + analytic_id
+        endpoint = voxu.urljoin(self.base_url, "analytics", analytic_id)
         res = self._requests.delete(endpoint, headers=self._header)
         _validate_response(res)
 
@@ -267,7 +268,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/data/list"
+        endpoint = voxu.urljoin(self.base_url, "data", "list")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["data"]
@@ -286,7 +287,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/data"
+        endpoint = voxu.urljoin(self.base_url, "data")
         res = self._requests.get(
             endpoint, headers=self._header, params=data_query.to_dict())
         _validate_response(res)
@@ -307,7 +308,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/data"
+        endpoint = voxu.urljoin(self.base_url, "data")
         filename = os.path.basename(path)
         mime_type = _get_mime_type(path)
         with open(path, "rb") as df:
@@ -348,7 +349,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/data/url"
+        endpoint = voxu.urljoin(self.base_url, "data", "url")
         data = {
             "signed_url": url,
             "filename": filename,
@@ -378,7 +379,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/data/" + data_id
+        endpoint = voxu.urljoin(self.base_url, "data", data_id)
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["data"]
@@ -401,7 +402,7 @@ class API(object):
         if not output_path:
             output_path = self.get_data_details(data_id)["name"]
 
-        endpoint = self.base_url + "/data/" + data_id + "/download"
+        endpoint = voxu.urljoin(self.base_url, "data", data_id, "download")
         self._stream_download(endpoint, output_path)
 
         return output_path
@@ -418,7 +419,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/data/" + data_id + "/download-url"
+        endpoint = voxu.urljoin(self.base_url, "data", data_id, "download-url")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["url"]
@@ -439,7 +440,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/data/" + data_id + "/ttl"
+        endpoint = voxu.urljoin(self.base_url, "data", data_id, "ttl")
         data = {"days": str(days)}
         res = self._requests.put(endpoint, headers=self._header, data=data)
         _validate_response(res)
@@ -453,7 +454,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/data/" + data_id
+        endpoint = voxu.urljoin(self.base_url, "data", data_id)
         res = self._requests.delete(endpoint, headers=self._header)
         _validate_response(res)
 
@@ -468,7 +469,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/list"
+        endpoint = voxu.urljoin(self.base_url, "jobs", "list")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["jobs"]
@@ -487,7 +488,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs"
+        endpoint = voxu.urljoin(self.base_url, "jobs")
         res = self._requests.get(
             endpoint, headers=self._header, params=jobs_query.to_dict())
         _validate_response(res)
@@ -513,7 +514,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs"
+        endpoint = voxu.urljoin(self.base_url, "jobs")
         files = {
             "file": ("job.json", str(job_request), "application/json"),
             "job_name": (None, job_name),
@@ -539,7 +540,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id)
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["job"]
@@ -557,7 +558,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/request"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "request")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return voxj.JobRequest.from_dict(_parse_json_response(res))
@@ -571,7 +572,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/start"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "start")
         res = self._requests.put(endpoint, headers=self._header)
         _validate_response(res)
 
@@ -591,7 +592,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/ttl"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "ttl")
         data = {"days": str(days)}
         res = self._requests.put(endpoint, headers=self._header, data=data)
         _validate_response(res)
@@ -605,7 +606,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/archive"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "archive")
         res = self._requests.put(endpoint, headers=self._header)
         _validate_response(res)
 
@@ -618,7 +619,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/unarchive"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "unarchive")
         res = self._requests.put(endpoint, headers=self._header)
         _validate_response(res)
 
@@ -730,7 +731,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/status"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "status")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)
@@ -745,7 +746,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/output"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "output")
         self._stream_download(endpoint, output_path)
 
     def get_job_output_download_url(self, job_id):
@@ -761,7 +762,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/output-url"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "output-url")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["url"]
@@ -783,7 +784,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/log"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "log")
         if output_path is None:
             res = self._requests.get(endpoint, headers=self._header)
             _validate_response(res)
@@ -808,7 +809,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/log-url"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "log-url")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["url"]
@@ -824,7 +825,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id)
         res = self._requests.delete(endpoint, headers=self._header)
         _validate_response(res)
 
@@ -839,7 +840,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/jobs/" + job_id + "/kill"
+        endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "kill")
         res = self._requests.put(endpoint, headers=self._header)
         _validate_response(res)
 
@@ -854,7 +855,7 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        endpoint = self.base_url + "/status/all"
+        endpoint = voxu.urljoin(self.base_url, "status", "all")
         res = self._requests.get(endpoint, headers=self._header)
         _validate_response(res)
         return _parse_json_response(res)["statuses"]

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -31,7 +31,6 @@ import voxel51.users.jobs as voxj
 import voxel51.users.utils as voxu
 
 
-_BASE_API_URL = "https://api.voxel51.com/v1"
 _CHUNK_SIZE = 32 * 1024 * 1024  # in bytes
 
 
@@ -65,10 +64,13 @@ class API(object):
             keep_alive (bool, optional): whether to keep the request session
                 alive between requests. By default, this is False
         '''
-        self.base_url = _BASE_API_URL
-        self.token = token if token is not None else voxa.load_token()
+        if token is None:
+            token = voxa.load_token()
+
+        self.base_url = voxu.urljoin(token.base_api_url, "v1")
+        self.token = token
         self.keep_alive = keep_alive
-        self._header = self.token.get_header()
+        self._header = token.get_header()
         self._requests = requests.Session() if keep_alive else requests
 
     def __enter__(self):

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -87,18 +87,20 @@ class API(object):
             self._requests.close()
 
     @classmethod
-    def from_json(cls, token_path):
+    def from_json(cls, token_path, **kwargs):
         '''Creates an API instance from the given Token JSON file.
 
         Args:
-            token_path: the path to a :class:`voxel51.users.auth.Token` JSON
-                file
+            token_path (str): the path to a :class:`voxel51.users.auth.Token`
+                JSON file
+            **kwargs (dict): optional keyword arguments for
+                `API(token=token, **kwargs)`
 
         Returns:
-            an API instance
+            an :class:`API` instance
         '''
         token = voxa.load_token(token_path=token_path)
-        return cls(token=token)
+        return cls(token=token, **kwargs)
 
     @staticmethod
     def thread_map(callback, iterable, max_workers=None):

--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -114,6 +114,7 @@ class Token(object):
     '''A class encapsulating an API authentication token.
 
     Attributes:
+        base_api_url (str): the base URL of the API for the token
         creation_date (str): the creation date of the token
         id (str): the ID of the token
     '''
@@ -124,9 +125,11 @@ class Token(object):
         Args:
             token_dict (dict): a JSON dictionary defining an API token
         '''
-        self.creation_date = token_dict["access_token"]["created_at"]
-        self.id = token_dict["access_token"]["token_id"]
-        self._private_key = token_dict["access_token"]["private_key"]
+        access_token = token_dict["access_token"]
+        self.base_api_url = self._parse_base_api_url(access_token)
+        self.creation_date = access_token["created_at"]
+        self.id = access_token["token_id"]
+        self._private_key = access_token["private_key"]
         self._token_dict = token_dict
 
     def __str__(self):
@@ -152,6 +155,18 @@ class Token(object):
             a Token instance
         '''
         return cls(voxu.read_json(path))
+
+    @staticmethod
+    def _parse_base_api_url(access_token):
+        base_api_url = access_token.get("base_api_url", None)
+        if base_api_url is None:
+            base_api_url = "https://api.voxel51.com"
+            logger.warning(
+                "No base API URL found in token; defaulting to '%s'. To "
+                "resolve this message, download a new API token from the "
+                "Platform", base_api_url)
+
+        return base_api_url
 
 
 class TokenError(Exception):

--- a/voxel51/users/utils.py
+++ b/voxel51/users/utils.py
@@ -31,6 +31,18 @@ from requests_toolbelt.multipart.encoder import MultipartEncoder
 logger = logging.getLogger(__name__)
 
 
+def urljoin(*args):
+    '''Combines the URL parts into a single URL.
+
+    Args:
+        *args: a list of URL parts
+
+    Returns:
+        the full URL
+    '''
+    return "/".join([a.strip("/") for a in args])
+
+
 def read_json(path):
     '''Reads JSON from file.
 


### PR DESCRIPTION
This is backwards compatible. Folks who are not lucky enough to have a base URL in their tokens will get a warning message suggesting that they download a new API token from their friendly local Platform.