### PR TITLE
Adding support for explicitly setting the expiration date when updating the TTL of data/jobs

### DIFF
--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -385,7 +385,7 @@ class TTLDataCommand(Command):
         if not failures:
             logger.info("Data TTL(s) updated")
         else:
-            for data_id, message in failures.items():
+            for data_id, message in iteritems(failures):
                 logger.warning(
                     "Failed to update TTL of data '%s': %s", data_id, message)
 
@@ -413,7 +413,7 @@ class DeleteDataCommand(Command):
             help="whether to force delete all without confirmation")
         parser.add_argument(
             "--dry-run", action="store_true",
-            help="whether to print data IDs that would be deleted rather than"
+            help="whether to print data IDs that would be deleted rather than "
             "actually performing the action")
 
     @staticmethod
@@ -444,7 +444,7 @@ class DeleteDataCommand(Command):
         if not failures:
             logger.info("Data deleted")
         else:
-            for data_id, message in failures.items():
+            for data_id, message in iteritems(failures):
                 logger.warning(
                     "Failed to delete data '%s': %s", data_id, message)
 
@@ -657,7 +657,7 @@ class StartJobsCommand(Command):
         # Start specific jobs
         voxel51 jobs start <id> [...]
 
-        # Start all eligible (i.e., unstarted) jobs
+        # Start all eligible (unstarted) jobs
         voxel51 jobs start --all
     '''
 
@@ -667,13 +667,13 @@ class StartJobsCommand(Command):
             "ids", nargs="*", metavar="ID", help="the job ID(s) to start")
         parser.add_argument(
             "-a", "--all", action="store_true",
-            help="whether to start all eligible jobs")
+            help="whether to start all eligible (unstarted) jobs")
         parser.add_argument(
             "-f", "--force", action="store_true",
             help="whether to force start all without confirmation")
         parser.add_argument(
             "--dry-run", action="store_true",
-            help="whether to print job IDs that would be started rather than"
+            help="whether to print job IDs that would be started rather than "
             "actually performing the action")
 
     @staticmethod
@@ -710,7 +710,7 @@ class StartJobsCommand(Command):
         if not failures:
             logger.info("Job(s) started")
         else:
-            for job_id, message in failures.items():
+            for job_id, message in iteritems(failures):
                 logger.warning("Failed to start job '%s': %s", job_id, message)
 
 
@@ -737,7 +737,7 @@ class ArchiveJobsCommand(Command):
             help="whether to force archive all without confirmation")
         parser.add_argument(
             "--dry-run", action="store_true",
-            help="whether to print job IDs that would be archived rather than"
+            help="whether to print job IDs that would be archived rather than "
             "actually performing the action")
 
     @staticmethod
@@ -773,7 +773,7 @@ class ArchiveJobsCommand(Command):
         if not failures:
             logger.info("Job(s) archived")
         else:
-            for job_id, message in failures.items():
+            for job_id, message in iteritems(failures):
                 logger.warning(
                     "Failed to archive job '%s': %s", job_id, message)
 
@@ -785,7 +785,7 @@ class UnarchiveJobsCommand(Command):
         # Unarchive specific jobs
         voxel51 jobs unarchive <id> [...]
 
-        # Unarchive all eligible (i.e., unexpired) jobs
+        # Unarchive all eligible (unexpired) jobs
         voxel51 jobs unarchive --all
     '''
 
@@ -795,7 +795,7 @@ class UnarchiveJobsCommand(Command):
             "ids", nargs="*", metavar="ID", help="the job ID(s) to unarchive")
         parser.add_argument(
             "-a", "--all", action="store_true",
-            help="whether to unarchive all eligible jobs")
+            help="whether to unarchive all eligible (unexpired) jobs")
         parser.add_argument(
             "-f", "--force", action="store_true",
             help="whether to force unarchive all without confirmation")
@@ -840,7 +840,7 @@ class UnarchiveJobsCommand(Command):
         if not failures:
             logger.info("Job(s) unarchived")
         else:
-            for job_id, message in failures.items():
+            for job_id, message in iteritems(failures):
                 logger.warning(
                     "Failed to unarchive job '%s': %s", job_id, message)
 
@@ -916,7 +916,7 @@ class TTLJobsCommand(Command):
         if not failures:
             logger.info("Job TTL(s) updated")
         else:
-            for job_id, message in failures.items():
+            for job_id, message in iteritems(failures):
                 logger.warning(
                     "Failed to update TTL of job '%s': %s", job_id, message)
 
@@ -1059,7 +1059,7 @@ class KillJobsCommand(Command):
         # Kill specific jobs
         voxel51 jobs kill <id> [...]
 
-        # Kill all eligible (i.e., queued or scheduled) jobs
+        # Kill all eligible (queued or scheduled) jobs
         voxel51 jobs kill --all
     '''
 
@@ -1069,13 +1069,13 @@ class KillJobsCommand(Command):
             "ids", nargs="*", metavar="ID", help="job ID(s) to kill")
         parser.add_argument(
             "-a", "--all", action="store_true",
-            help="whether to kill all eligible jobs")
+            help="whether to kill all eligible (queued or scheduled) jobs")
         parser.add_argument(
             "-f", "--force", action="store_true",
             help="whether to force kill all without confirmation")
         parser.add_argument(
             "--dry-run", action="store_true",
-            help="whether to print job IDs that would be killed rather than"
+            help="whether to print job IDs that would be killed rather than "
             "actually performing the action")
 
     @staticmethod
@@ -1112,7 +1112,7 @@ class KillJobsCommand(Command):
         if not failures:
             logger.info("Job(s) killed")
         else:
-            for job_id, message in failures.items():
+            for job_id, message in iteritems(failures):
                 logger.warning("Failed to kill job '%s': %s", job_id, message)
 
 
@@ -1123,7 +1123,7 @@ class DeleteJobsCommand(Command):
         # Delete specific jobs
         voxel51 jobs delete <id> [...]
 
-        # Delete all eligible (i.e., unstarted) jobs
+        # Delete all eligible (unstarted) jobs
         voxel51 jobs delete --all
     '''
 
@@ -1133,13 +1133,13 @@ class DeleteJobsCommand(Command):
             "ids", nargs="*", metavar="ID", help="job ID(s) to delete")
         parser.add_argument(
             "-a", "--all", action="store_true",
-            help="whether to delete all eligible jobs")
+            help="whether to delete all eligible (unstarted) jobs")
         parser.add_argument(
             "-f", "--force", action="store_true",
             help="whether to force delete all without confirmation")
         parser.add_argument(
             "--dry-run", action="store_true",
-            help="whether to print job IDs that would be deleted rather than"
+            help="whether to print job IDs that would be deleted rather than "
             "actually performing the action")
 
     @staticmethod
@@ -1176,7 +1176,7 @@ class DeleteJobsCommand(Command):
         if not failures:
             logger.info("Job(s) deleted")
         else:
-            for job_id, message in failures.items():
+            for job_id, message in iteritems(failures):
                 logger.warning(
                     "Failed to delete job '%s': %s", job_id, message)
 
@@ -1539,6 +1539,13 @@ def _render_datetime(datetime_str):
     return dt.astimezone(get_localzone()).strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
+def _get_batch_failures(batch_response):
+    return {
+        id: status.get("message") for id, status in iteritems(batch_response)
+        if not status["success"]
+    }
+
+
 def _abort_if_requested():
     should_continue = voxu.query_yes_no(
         "Are you sure you want to continue?", default="no")
@@ -1567,13 +1574,6 @@ def _register_command(parent, name, command):
     parser.set_defaults(run=command.run)
     command.setup(parser)
     return parser
-
-
-def _get_batch_failures(batch_result):
-    return {
-        id: status.get("message") for id, status in batch_result.items()
-            if not status["success"]
-    }
 
 
 def main():

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -849,11 +849,11 @@ class TTLJobsCommand(Command):
     '''Update TTL of jobs on the platform.
 
     Examples:
-        # Update TTL of jobs
+        # Extend TTL of jobs by given number of days
         voxel51 jobs ttl --days <days> <id> [...]
 
-        # Update TTL of all eligible (i.e., unexpired) jobs
-        voxel51 jobs ttl --days <days> --all
+        # Set expiration date of jobs to given date
+        voxel51 jobs ttl --date <date> <id> [...]
     '''
 
     @staticmethod
@@ -861,24 +861,26 @@ class TTLJobsCommand(Command):
         parser.add_argument(
             "ids", nargs="*", metavar="ID", help="the job ID(s) to update")
         parser.add_argument(
-            "-d", "--days", metavar="DAYS", type=float,
+            "--days", metavar="DAYS", type=float,
             help="the number of days by which to extend the TTL of the jobs")
         parser.add_argument(
+            "--date", metavar="DATE", help="new expiration date for the jobs")
+        parser.add_argument(
             "-a", "--all", action="store_true",
-            help="whether to update all eligible jobs")
+            help="whether to update all eligible (unexpired) jobs")
         parser.add_argument(
             "-f", "--force", action="store_true",
             help="whether to force update all without confirmation")
         parser.add_argument(
             "--dry-run", action="store_true",
-            help="whether to print job IDs that would be updated rather than"
+            help="whether to print job IDs that would be updated rather than "
             "actually performing the action")
 
     @staticmethod
     def run(args):
         api = API()
 
-        if not args.days:
+        if not args.days and not args.date:
             return
 
         if args.all:
@@ -909,7 +911,8 @@ class TTLJobsCommand(Command):
             return
 
         failures = _get_batch_failures(
-            api.batch_update_jobs_ttl(job_ids, args.days))
+            api.batch_update_jobs_ttl(
+                job_ids, days=args.days, expiration_date=args.date))
         if not failures:
             logger.info("Job TTL(s) updated")
         else:

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -325,11 +325,11 @@ class TTLDataCommand(Command):
     '''Update TTL of data on the platform.
 
     Examples:
-        # Update TTL of data
+        # Extend TTL of data by specified number of days
         voxel51 data ttl --days <days> <id> [...]
 
-        # Update TTL of all data
-        voxel51 data ttl --days <days> --all
+        # Set expiration date of data to given date
+        voxel51 data ttl --date <date> <id> [...]
     '''
 
     @staticmethod
@@ -337,8 +337,10 @@ class TTLDataCommand(Command):
         parser.add_argument(
             "ids", nargs="*", metavar="ID", help="the data ID(s) to update")
         parser.add_argument(
-            "-d", "--days", metavar="DAYS", type=float,
+            "--days", metavar="DAYS", type=float,
             help="the number of days by which to extend the TTL of the data")
+        parser.add_argument(
+            "--date", metavar="DATE", help="new expiration date for the data")
         parser.add_argument(
             "-a", "--all", action="store_true",
             help="whether to update all data")
@@ -347,14 +349,14 @@ class TTLDataCommand(Command):
             help="whether to force update all without confirmation")
         parser.add_argument(
             "--dry-run", action="store_true",
-            help="whether to print data IDs that would be updated rather than"
+            help="whether to print data IDs that would be updated rather than "
             "actually performing the action")
 
     @staticmethod
     def run(args):
         api = API()
 
-        if not args.days:
+        if not args.days and not args.date:
             return
 
         if args.all:
@@ -378,7 +380,8 @@ class TTLDataCommand(Command):
             return
 
         failures = _get_batch_failures(
-            api.batch_update_data_ttl(data_ids, args.days))
+            api.batch_update_data_ttl(
+                data_ids, days=args.days, expiration_date=args.date))
         if not failures:
             logger.info("Data TTL(s) updated")
         else:

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -487,17 +487,23 @@ class API(object):
         res = self._requests.delete(endpoint, headers=self._header)
         _validate_response(res)
 
-    def batch_update_data_ttl(self, data_ids, days):
+    def batch_update_data_ttl(self, data_ids, days=None, expiration_date=None):
         '''Updates the expiration date of the data with the given IDs.
 
-        To decrease the lifespan of the data, provide a negative number. Note
-        that if the expiration date of data after modification is in the past,
-        the data will be deleted.
+        Note that if the expiration date of the data after modification is in
+        the past, the data will be deleted.
+
+        Exactly one keyword argument must be provided.
 
         Args:
             data_ids (list): the data IDs
-            days (float): the number of days by which to extend the lifespan
-                of the data
+            days (float, optional): the number of days by which to extend the
+                lifespan of the data. To decrease the lifespan of the data,
+                provide a negative number
+            expiration_date (datetime|str, optional): a new TTL for the data.
+                If a string is provided, it must be in ISO 8601 format, e.g.,
+                "YYYY-MM-DDThh:mm:ss.sssZ". If a non-UTC timezone is included
+                in the datetime or string, it will be respected
 
         Returns:
             a dictionary mapping data IDs to True/False values indicating
@@ -506,7 +512,15 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        return self._batch_request("data", "ttl", data_ids, {"days": days})
+        data = {}
+        if days is not None:
+            data["days"] = str(days)
+        if expiration_date is not None:
+            data["expiration_date"] = _parse_datetime(expiration_date)
+        if len(data) != 1:
+            raise APIError(
+                "Either `days` or `expiration_date` must be provided", 400)
+        return self._batch_request("data", "ttl", data_ids, data)
 
     def batch_delete_data(self, data_ids):
         '''Deletes the data with the given IDs.
@@ -977,18 +991,24 @@ class API(object):
         '''
         return self._batch_request("jobs", "unarchive", job_ids)
 
-    def batch_update_jobs_ttl(self, job_ids, days):
+    def batch_update_jobs_ttl(self, job_ids, days=None, expiration_date=None):
         '''Updates the expiration dates of the jobs with the given IDs by the
         specified number of days.
 
-        To decrease the lifespan of the jobs, provide a negative number. Note
-        that if the expiration date of a job after modification is in the
-        past, the job will be deleted.
+        Note that if the expiration date of the job after modification is in
+        the past, the job output will be deleted.
+
+        Exactly one keyword argument must be provided.
 
         Args:
             job_ids (list): the job IDs
-            days (float): the number of days by which to extend the lifespan
-                of the jobs
+            days (float, optional): the number of days by which to extend the
+                lifespan of the job. To decrease the lifespan of the job,
+                provide a negative number
+            expiration_date (datetime|str, optional): a new TTL for the job.
+                If a string is provided, it must be in ISO 8601 format, e.g.,
+                "YYYY-MM-DDThh:mm:ss.sssZ". If a non-UTC timezone is included
+                in the datetime or string, it will be respected
 
         Returns:
             a dictionary mapping job IDs to True/False values indicating
@@ -997,7 +1017,15 @@ class API(object):
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
-        return self._batch_request("jobs", "ttl", job_ids, {"days": days})
+        data = {}
+        if days is not None:
+            data["days"] = str(days)
+        if expiration_date is not None:
+            data["expiration_date"] = _parse_datetime(expiration_date)
+        if len(data) != 1:
+            raise APIError(
+                "Either `days` or `expiration_date` must be provided", 400)
+        return self._batch_request("jobs", "ttl", job_ids, data)
 
     def batch_delete_jobs(self, job_ids):
         '''Deletes the jobs with the given IDs.

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -506,8 +506,9 @@ class API(object):
                 in the datetime or string, it will be respected
 
         Returns:
-            a dictionary mapping data IDs to True/False values indicating
-                whether the data was successfully processed (True)
+            a dictionary mapping data IDs to dictionaries indicating whether
+                the data was successfully processed. The ``status`` field will
+                be set to ``True`` on success or ``False`` on failure
 
         Raises:
             :class:`APIError` if the request was unsuccessful
@@ -529,8 +530,9 @@ class API(object):
             data_ids (list): the data IDs
 
         Returns:
-            a dictionary mapping data IDs to True/False values indicating
-                whether the data was successfully processed (True)
+            a dictionary mapping data IDs to dictionaries indicating whether
+                the data was successfully processed. The ``status`` field will
+                be set to ``True`` on success or ``False`` on failure
 
         Raises:
             :class:`APIError` if the request was unsuccessful
@@ -953,8 +955,9 @@ class API(object):
             job_ids (list): the job IDs
 
         Returns:
-            a dictionary mapping job IDs to True/False values indicating
-                whether the job was successfully processed (True)
+            a dictionary mapping job IDs to dictionaries indicating whether
+                the job was successfully processed. The ``status`` field will
+                be set to ``True`` on success or ``False`` on failure
 
         Raises:
             :class:`APIError` if the request was unsuccessful
@@ -968,8 +971,9 @@ class API(object):
             job_ids (list): the job IDs
 
         Returns:
-            a dictionary mapping job IDs to True/False values indicating
-                whether the job was successfully processed (True)
+            a dictionary mapping job IDs to dictionaries indicating whether
+                the job was successfully processed. The ``status`` field will
+                be set to ``True`` on success or ``False`` on failure
 
         Raises:
             :class:`APIError` if the request was unsuccessful
@@ -983,8 +987,9 @@ class API(object):
             job_ids (list): the job IDs
 
         Returns:
-            a dictionary mapping job IDs to True/False values indicating
-                whether the job was successfully processed (True)
+            a dictionary mapping job IDs to dictionaries indicating whether
+                the job was successfully processed. The ``status`` field will
+                be set to ``True`` on success or ``False`` on failure
 
         Raises:
             :class:`APIError` if the request was unsuccessful
@@ -1011,8 +1016,9 @@ class API(object):
                 in the datetime or string, it will be respected
 
         Returns:
-            a dictionary mapping job IDs to True/False values indicating
-                whether the job was successfully processed (True)
+            a dictionary mapping job IDs to dictionaries indicating whether
+                the job was successfully processed. The ``status`` field will
+                be set to ``True`` on success or ``False`` on failure
 
         Raises:
             :class:`APIError` if the request was unsuccessful
@@ -1036,8 +1042,9 @@ class API(object):
             job_ids (list): the job IDs
 
         Returns:
-            a dictionary mapping job IDs to True/False values indicating
-                whether the job was successfully processed (True)
+            a dictionary mapping job IDs to dictionaries indicating whether
+                the job was successfully processed. The ``status`` field will
+                be set to ``True`` on success or ``False`` on failure
 
         Raises:
             :class:`APIError` if the request was unsuccessful
@@ -1053,8 +1060,9 @@ class API(object):
             job_ids (list): the job IDs
 
         Returns:
-            a dictionary mapping job IDs to True/False values indicating
-                whether the job was successfully processed (True)
+            a dictionary mapping job IDs to dictionaries indicating whether
+                the job was successfully processed. The ``status`` field will
+                be set to ``True`` on success or ``False`` on failure
 
         Raises:
             :class:`APIError` if the request was unsuccessful

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -424,24 +424,38 @@ class API(object):
         _validate_response(res)
         return _parse_json_response(res)["url"]
 
-    def update_data_ttl(self, data_id, days):
-        '''Updates the expiration date of the data by the specified number of
-        days.
+    def update_data_ttl(self, data_id, days=None, expiration_date=None):
+        '''Updates the expiration date of the data.
 
-        To decrease the lifespan of the data, provide a negative number. Note
-        that if the expiration date of the data after modification is in the
-        past, the data will be deleted.
+        Note that if the expiration date of the data after modification is in
+        the past, the data will be deleted.
+
+        Exactly one keyword argument must be provided.
 
         Args:
             data_id (str): the data ID
-            days (float): the number of days by which to extend the lifespan
-                of the data
+            days (float, optional): the number of days by which to extend the
+                lifespan of the data. To decrease the lifespan of the data,
+                provide a negative number
+            expiration_date (datetime|str, optional): a new TTL for the data.
+                If a string is provided, it must be in ISO 8601 format, e.g.,
+                "YYYY-MM-DDThh:mm:ss.sssZ". If a non-UTC timezone is included
+                in the datetime or string, it will be respected
 
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
         endpoint = voxu.urljoin(self.base_url, "data", data_id, "ttl")
-        data = {"days": str(days)}
+
+        data = {}
+        if days is not None:
+            data["days"] = str(days)
+        if expiration_date is not None:
+            data["expiration_date"] = _parse_datetime(expiration_date)
+        if len(data) != 1:
+            raise APIError(
+                "Either `days` or `expiration_date` must be provided", 400)
+
         res = self._requests.put(endpoint, headers=self._header, data=data)
         _validate_response(res)
 
@@ -576,24 +590,38 @@ class API(object):
         res = self._requests.put(endpoint, headers=self._header)
         _validate_response(res)
 
-    def update_job_ttl(self, job_id, days):
-        '''Updates the expiration date of the job by the specified number of
-        days.
+    def update_job_ttl(self, job_id, days=None, expiration_date=None):
+        '''Updates the expiration date of the job.
 
-        To decrease the lifespan of the job, provide a negative number. Note
-        that if the expiration date of the job after modification is in the
-        past, the job will be deleted.
+        Note that if the expiration date of the job after modification is in
+        the past, the job output will be deleted.
+
+        Exactly one keyword argument must be provided.
 
         Args:
             job_id (str): the job ID
-            days (float): the number of days by which to extend the lifespan
-                of the job
+            days (float, optional): the number of days by which to extend the
+                lifespan of the job. To decrease the lifespan of the job,
+                provide a negative number
+            expiration_date (datetime|str, optional): a new TTL for the job.
+                If a string is provided, it must be in ISO 8601 format, e.g.,
+                "YYYY-MM-DDThh:mm:ss.sssZ". If a non-UTC timezone is included
+                in the datetime or string, it will be respected
 
         Raises:
             :class:`APIError` if the request was unsuccessful
         '''
         endpoint = voxu.urljoin(self.base_url, "jobs", job_id, "ttl")
-        data = {"days": str(days)}
+
+        data = {}
+        if days is not None:
+            data["days"] = str(days)
+        if expiration_date is not None:
+            data["expiration_date"] = _parse_datetime(expiration_date)
+        if len(data) != 1:
+            raise APIError(
+                "Either `days` or `expiration_date` must be provided", 400)
+
         res = self._requests.put(endpoint, headers=self._header, data=data)
         _validate_response(res)
 

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -997,8 +997,7 @@ class API(object):
         return self._batch_request("jobs", "unarchive", job_ids)
 
     def batch_update_jobs_ttl(self, job_ids, days=None, expiration_date=None):
-        '''Updates the expiration dates of the jobs with the given IDs by the
-        specified number of days.
+        '''Updates the expiration dates of the jobs with the given IDs.
 
         Note that if the expiration date of the job after modification is in
         the past, the job output will be deleted.

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -672,7 +672,7 @@ class API(object):
         elif job is not None:
             state = job["state"]
         else:
-            raise APIError("Must provide a keyword argument")
+            raise APIError("Either `job_id` or `job` must be provided", 400)
 
         return state
 
@@ -741,7 +741,7 @@ class API(object):
         elif job is not None:
             expiration_date = job["expiration_date"]
         else:
-            raise APIError("Must provide a keyword argument")
+            raise APIError("Either `job_id` or `job` must be provided", 400)
 
         expiration = dateutil.parser.parse(expiration_date)
         now = datetime.utcnow()

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -488,7 +488,7 @@ class API(object):
         _validate_response(res)
 
     def batch_update_data_ttl(self, data_ids, days=None, expiration_date=None):
-        '''Updates the expiration date of the data with the given IDs.
+        '''Updates the expiration dates of the data with the given IDs.
 
         Note that if the expiration date of the data after modification is in
         the past, the data will be deleted.
@@ -500,10 +500,10 @@ class API(object):
             days (float, optional): the number of days by which to extend the
                 lifespan of the data. To decrease the lifespan of the data,
                 provide a negative number
-            expiration_date (datetime|str, optional): a new TTL for the data.
-                If a string is provided, it must be in ISO 8601 format, e.g.,
-                "YYYY-MM-DDThh:mm:ss.sssZ". If a non-UTC timezone is included
-                in the datetime or string, it will be respected
+            expiration_date (datetime|str, optional): a new expiration date for
+                the data. If a string is provided, it must be in ISO 8601
+                format, e.g., "YYYY-MM-DDThh:mm:ss.sssZ". If a non-UTC timezone
+                is included in the datetime or string, it will be respected
 
         Returns:
             a dictionary mapping data IDs to dictionaries indicating whether
@@ -999,7 +999,7 @@ class API(object):
     def batch_update_jobs_ttl(self, job_ids, days=None, expiration_date=None):
         '''Updates the expiration dates of the jobs with the given IDs.
 
-        Note that if the expiration date of the job after modification is in
+        Note that if the expiration date of a job after modification is in
         the past, the job output will be deleted.
 
         Exactly one keyword argument must be provided.
@@ -1007,12 +1007,12 @@ class API(object):
         Args:
             job_ids (list): the job IDs
             days (float, optional): the number of days by which to extend the
-                lifespan of the job. To decrease the lifespan of the job,
+                lifespan of each job. To decrease the lifespan of the jobs,
                 provide a negative number
-            expiration_date (datetime|str, optional): a new TTL for the job.
-                If a string is provided, it must be in ISO 8601 format, e.g.,
-                "YYYY-MM-DDThh:mm:ss.sssZ". If a non-UTC timezone is included
-                in the datetime or string, it will be respected
+            expiration_date (datetime|str, optional): a new expiration date for
+                each job. If a string is provided, it must be in ISO 8601
+                format, e.g., "YYYY-MM-DDThh:mm:ss.sssZ". If a non-UTC timezone
+                is included in the datetime or string, it will be respected
 
         Returns:
             a dictionary mapping job IDs to dictionaries indicating whether


### PR DESCRIPTION
This PR assumes that the API will support an optional `expiration_date` field to `PUT v1/jobs:jobId:ttl`
JS: https://github.com/voxel51/api-js/pull/59