### PR TITLE
Adding CLI command to get status of platform services

### DIFF
--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -81,6 +81,7 @@ class Voxel51Command(Command):
         _register_command(subparsers, "data", DataCommand)
         _register_command(subparsers, "jobs", JobsCommand)
         _register_command(subparsers, "analytics", AnalyticsCommand)
+        _register_command(subparsers, "status", StatusCommand)
 
 
 class AuthCommand(Command):
@@ -1506,6 +1507,63 @@ class DeleteAnalyticsCommand(Command):
         for analytic_id in analytic_ids:
             api.delete_analytic(analytic_id)
             logger.info("Analytic '%s' deleted", analytic_id)
+
+
+class StatusCommand(Command):
+    '''Tools for checking the status of the platform.
+
+    Examples:
+        # Check status of all platform services
+        voxel51 status
+
+        # Check whether platform is up
+        voxel51 status --platform
+
+        # Check whether jobs cluster is up
+        voxel51 status --jobs-cluster
+    '''
+
+    @staticmethod
+    def setup(parser):
+        parser.add_argument(
+            "-p", "--platform", action="store_true",
+            help="check if platform is up")
+        parser.add_argument(
+            "-j", "--jobs-cluster", action="store_true",
+            help="check if jobs cluster is up")
+
+    @staticmethod
+    def run(args):
+        api = API()
+
+        status = api.get_platform_status()
+
+        if args.platform:
+            logger.info(status["platform"])
+
+        if args.jobs_cluster:
+            logger.info(status["jobs"])
+
+        if not args.platform and not args.jobs_cluster:
+            _print_platform_status_info(status, api.token)
+
+
+def _print_platform_status_info(status, token):
+    records = []
+    for service, is_up in iteritems(status):
+        if is_up:
+            msg = "system operational!"
+        elif token.base_api_url == "https://api.voxel51.com":
+            msg = "system down; see https://status.voxel51.com for more info"
+        else:
+            msg = "system down; contact your sys admin for more info"
+
+        records.append((service, is_up, msg))
+
+    table_str = tabulate(
+        records, headers=["service", "operational", "message"],
+        tablefmt=TABLE_FORMAT)
+    logger.info(table_str)
 
 
 def _print_active_token_info():

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1570,9 +1570,9 @@ def _print_active_token_info():
     token_path = voxa.get_active_token_path()
     token = voxa.load_token(token_path=token_path)
     contents = [
-        ("id", token.id),
+        ("token id", token.id),
         ("creation date", _render_datetime(token.creation_date)),
-        ("base API URL", token.base_api_url),
+        ("base api url", token.base_api_url),
         ("path", token_path),
     ]
     table_str = tabulate(


### PR DESCRIPTION
```
$ voxel51 status -h
usage: voxel51 status [-h] [-p] [-j]

Tools for checking the status of the platform.

    Examples:
        # Check status of all platform services
        voxel51 status

        # Check whether platform is up
        voxel51 status --platform

        # Check whether jobs cluster is up
        voxel51 status --jobs-cluster

optional arguments:
  -h, --help          show this help message and exit
  -p, --platform      check if platform is up
  -j, --jobs-cluster  check if jobs cluster is up
```

Functioning platform:
```
$ voxel51 status
service    operational    message
---------  -------------  -------------------
platform   True           system operational!
jobs       True           system operational!
```

If production platform were down:
```
$ voxel51 status
service    operational    message
---------  -------------  ---------------------------------------------------------
platform   False          system down; see https://status.voxel51.com for more info
jobs       False          system down; see https://status.voxel51.com for more info
```

If other platform (eg, on-premises deployment) were down:
```
$ voxel51 status
service    operational    message
---------  -------------  -------------------------------------------------
platform   False          system down; contact your sys admin for more info
jobs       False          system down; contact your sys admin for more info
```
