### PR TITLE
Updating parsing of batch action failures

### DIFF
--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1621,10 +1621,10 @@ def _render_datetime(datetime_str):
     return dt.astimezone(get_localzone()).strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
-def _get_batch_failures(batch_response):
+def _get_batch_failures(response):
     return {
-        id: status.get("message") for id, status in iteritems(batch_response)
-        if not status["success"]
+        id: status.get("error", {}).get("message", "-")
+        for id, status in iteritems(response) if not status["success"]
     }
 
 

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1623,7 +1623,7 @@ def _render_datetime(datetime_str):
 
 def _get_batch_failures(response):
     return {
-        id: status.get("error", {}).get("message", "-")
+        id: status.get("error", {}).get("message", "????")
         for id, status in iteritems(response) if not status["success"]
     }
 


### PR DESCRIPTION
To be merged after serverside is updated to return error responses with the syntax below:

```
{
    "error": {
        "code": 404,
        "message": "XXXXX"
    }
}
```