### PR TITLE
Adding two useful help-related features to the CLI

### DIFF
--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1791,7 +1791,5 @@ _ADD_RECURSIVE_HELP_FLAGS = True
 def main():
     '''Executes the `voxel51` tool with the given command-line args.'''
     parser = _register_main_command(Voxel51Command, version=voxc.VERSION_LONG)
-
-
     args = parser.parse_args()
     args.run(args)

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1734,7 +1734,7 @@ def _iter_subparsers(parser):
 
 class _RecursiveHelpAction(argparse._HelpAction):
 
-    def __call__(self, parser, namespace, values, option_string=None):
+    def __call__(self, parser, *args, **kwargs):
         self._recurse(parser)
         parser.exit()
 

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1740,7 +1740,7 @@ class _RecursiveHelpAction(argparse._HelpAction):
 
     @staticmethod
     def _recurse(parser):
-        print("\n%s\n%s" % ("*" * 80, parser.format_help()))
+        print("\n%s\n%s" % ("*" * 79, parser.format_help()))
         for subparser in _iter_subparsers(parser):
             _RecursiveHelpAction._recurse(subparser)
 

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -61,14 +61,15 @@ class Command(object):
         raise NotImplementedError("subclass must implement setup()")
 
     @staticmethod
-    def run(args):
-        '''Execute the command on the given args.
+    def run(parser, args):
+        '''Executes the command on the given args.
 
         args:
+            parser: the `argparse.ArgumentParser` instance for the command
             args: an `argparse.Namespace` instance containing the arguments
                 for the command
         '''
-        pass
+        raise NotImplementedError("subclass must implement run()")
 
 
 class Voxel51Command(Command):
@@ -83,6 +84,10 @@ class Voxel51Command(Command):
         _register_command(subparsers, "analytics", AnalyticsCommand)
         _register_command(subparsers, "status", StatusCommand)
 
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
+
 
 class AuthCommand(Command):
     '''Tools for configuring API tokens.'''
@@ -93,6 +98,10 @@ class AuthCommand(Command):
         _register_command(subparsers, "show", ShowAuthCommand)
         _register_command(subparsers, "activate", ActivateAuthCommand)
         _register_command(subparsers, "deactivate", DeactivateAuthCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class ShowAuthCommand(Command):
@@ -108,7 +117,7 @@ class ShowAuthCommand(Command):
         pass
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         _print_active_token_info()
 
 
@@ -126,7 +135,7 @@ class ActivateAuthCommand(Command):
             "activate", help="path to API token to activate")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         voxa.activate_token(args.activate)
 
 
@@ -138,7 +147,7 @@ class DeactivateAuthCommand(Command):
         pass
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         voxa.deactivate_token()
 
 
@@ -154,6 +163,10 @@ class DataCommand(Command):
         _register_command(subparsers, "download", DownloadDataCommand)
         _register_command(subparsers, "ttl", TTLDataCommand)
         _register_command(subparsers, "delete", DeleteDataCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class ListDataCommand(Command):
@@ -217,7 +230,7 @@ class ListDataCommand(Command):
             help="whether to sort in ascending order")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         query = DataQuery().add_all_fields()
@@ -250,7 +263,7 @@ class InfoDataCommand(Command):
             "ids", nargs="+", metavar="ID", help="the data ID(s) of interest")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         data = [api.get_data_details(data_id) for data_id in args.ids]
@@ -271,7 +284,7 @@ class UploadDataCommand(Command):
             "paths", nargs="+", metavar="PATH", help="the file(s) to upload")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         uploads = []
@@ -308,7 +321,7 @@ class DownloadDataCommand(Command):
             help="generate signed URL to download data")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         data_id = args.id
@@ -354,7 +367,7 @@ class TTLDataCommand(Command):
             "actually performing the action")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if not args.days and not args.date:
@@ -419,7 +432,7 @@ class DeleteDataCommand(Command):
             "actually performing the action")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if args.all:
@@ -472,6 +485,10 @@ class JobsCommand(Command):
         _register_command(subparsers, "download", DownloadJobsCommand)
         _register_command(subparsers, "kill", KillJobsCommand)
         _register_command(subparsers, "delete", DeleteJobsCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class ListJobsCommand(Command):
@@ -592,7 +609,7 @@ class ListJobsCommand(Command):
             "--expired-only", action="store_true", help="only expired jobs")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         query = JobsQuery().add_all_fields()
@@ -655,7 +672,7 @@ class InfoJobsCommand(Command):
             "ids", nargs="+", metavar="ID", help="the job ID(s) of interest")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         jobs = [api.get_job_details(job_id) for job_id in args.ids]
@@ -682,7 +699,7 @@ class UploadJobsCommand(Command):
             help="whether to automatically start job")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         request = JobRequest.from_json(args.path)
@@ -723,7 +740,7 @@ class StartJobsCommand(Command):
             "actually performing the action")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if args.all:
@@ -789,7 +806,7 @@ class ArchiveJobsCommand(Command):
             "actually performing the action")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if args.all:
@@ -855,7 +872,7 @@ class UnarchiveJobsCommand(Command):
             "than actually performing the action")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if args.all:
@@ -929,7 +946,7 @@ class TTLJobsCommand(Command):
             "actually performing the action")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if not args.days and not args.date:
@@ -992,7 +1009,7 @@ class RequestJobsCommand(Command):
             "-p", "--path", metavar="PATH", help="path to write request JSON")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         request = api.get_job_request(args.id)
@@ -1023,7 +1040,7 @@ class StatusJobsCommand(Command):
             "-p", "--path", metavar="PATH", help="path to write status JSON")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         status = api.get_job_status(args.id)
@@ -1054,7 +1071,7 @@ class LogJobsCommand(Command):
             "-p", "--path", metavar="PATH", help="path to write logfile")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if args.path:
@@ -1091,7 +1108,7 @@ class DownloadJobsCommand(Command):
             help="generate signed URL to download job output")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         job_id = args.download
@@ -1132,7 +1149,7 @@ class KillJobsCommand(Command):
             "actually performing the action")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if args.all:
@@ -1198,7 +1215,7 @@ class DeleteJobsCommand(Command):
             "actually performing the action")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         if args.all:
@@ -1249,6 +1266,10 @@ class AnalyticsCommand(Command):
         _register_command(subparsers, "doc", DocAnalyticsCommand)
         _register_command(subparsers, "upload", UploadAnalyticsCommand)
         _register_command(subparsers, "delete", DeleteAnalyticsCommand)
+
+    @staticmethod
+    def run(parser, args):
+        parser.print_help()
 
 
 class ListAnalyticsCommand(Command):
@@ -1348,7 +1369,7 @@ class ListAnalyticsCommand(Command):
             help="only pending analytics")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         query = AnalyticsQuery().add_all_fields()
@@ -1399,7 +1420,7 @@ class InfoAnalyticsCommand(Command):
             help="the analytic ID(s) of interest")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         analytics = [
@@ -1425,7 +1446,7 @@ class DocAnalyticsCommand(Command):
             "-p", "--path", metavar="PATH", help="path to write doc JSON")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         doc = api.get_analytic_doc(args.id)
@@ -1470,7 +1491,7 @@ class UploadAnalyticsCommand(Command):
             "--image-type", help="type of image being uploaded")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         # Upload analytic documentation
@@ -1510,7 +1531,7 @@ class DeleteAnalyticsCommand(Command):
             help="whether to force delete without confirmation")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         analytic_ids = args.ids
@@ -1549,7 +1570,7 @@ class StatusCommand(Command):
             help="check if jobs cluster is up")
 
     @staticmethod
-    def run(args):
+    def run(parser, args):
         api = API()
 
         status = api.get_platform_status()
@@ -1698,6 +1719,10 @@ def _abort_if_requested():
 
 def _register_main_command(command, version=None):
     parser = argparse.ArgumentParser(description=command.__doc__.rstrip())
+
+    parser.set_defaults(run=lambda args: command.run(parser, args))
+    command.setup(parser)
+
     if version:
         parser.add_argument(
             "-v", "--version", action="version", version=version,
@@ -1713,7 +1738,8 @@ def _register_command(parent, name, command):
         name, help=command.__doc__.splitlines()[0],
         description=command.__doc__.rstrip(),
         formatter_class=argparse.RawTextHelpFormatter)
-    parser.set_defaults(run=command.run)
+
+    parser.set_defaults(run=lambda args: command.run(parser, args))
     command.setup(parser)
     return parser
 
@@ -1722,9 +1748,6 @@ def main():
     '''Executes the `voxel51` tool with the given command-line args.'''
     parser = _register_main_command(Voxel51Command, version=voxc.VERSION_LONG)
 
-    if len(sys.argv) == 1:
-        parser.print_help()
-        return
 
     args = parser.parse_args()
     args.run(args)


### PR DESCRIPTION
This PR adds two convenient features:

1. Running a naked `voxel51 <command>` will now print help for that command. Previously, it would just execute the command, which may do something, do nothing, or give an error.

This is useful because a typical pattern for exploring a CLI is to:
- Run `voxel51` to see what the tool is all about (expecting to get help info)
- See an interesting command in the above list
- Run `voxel51 <command>` to learn more about that command (expecting to get help info)

2. Automagically adding an `--all-help` flag for all commands that have subcommands. This is useful for seeing everything that one can do with a given command. Or, if one is so inclined, running `voxel51 --all-help` to see EVERYTHING