### PR TITLE
Updating docs to include CLI help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ __pycache__
 /docs/build/
 /docs/source/*.rst
 !/docs/source/index.rst
-!/docs/source/readme.rst
+!/docs/source/README.rst
+!/docs/source/CLI.rst
+!/docs/source/APPLICATIONS.rst

--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -1,4 +1,4 @@
-# Voxel51 Platform API for Applications Quickstart
+# Voxel51 Platform API Applications Quickstart
 
 The Voxel51 Platform provides an interface through which you can upload and
 manage data for your application users and run jobs that process their data
@@ -26,8 +26,8 @@ on the Voxel51 Platform.
 ### Sign-up and Authentication
 
 To use the API with your application, you must first login to your application
-admin account at https://console.voxel51.com/admin and create an API token
-for your application.
+admin account at https://console.voxel51.com/apps/your-app-name and create an
+API token for your application.
 
 > Keep your application API token private; it is your access key to the API.
 
@@ -36,7 +36,7 @@ activate your application token, set the `VOXEL51_APP_TOKEN` environment
 variable in your shell to point to your API token file:
 
 ```shell
-export VOXEL51_APP_TOKEN="/path/to/your/app-token.json"
+export VOXEL51_APP_TOKEN=/path/to/your/app-token.json
 ```
 
 Alternatively, you can permanently activate an application token by executing

--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -1,4 +1,4 @@
-# Voxel51 Platform API Applications Quickstart
+# Applications Quickstart
 
 The Voxel51 Platform provides an interface through which you can upload and
 manage data for your application users and run jobs that process their data

--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -8,8 +8,8 @@ In particular, the API exposes routes to manage your application, including
 uploading custom analytics, creating and managing users, monitoring the status
 of jobs, etc.
 
-This document provides a brief overview of using the Python Client Library
-to operate your application on the Voxel51 Platform.
+This document provides a brief overview of using this client library to
+operate your application on the Voxel51 Platform.
 
 <img src="https://drive.google.com/uc?id=1j0S8pLsopAqF1Ik3rf-CdyAIU4kA0sOP" alt="voxel51-logo.png" width="40%"/>
 

--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -1,0 +1,122 @@
+# Voxel51 Platform API for Applications Quickstart
+
+The Voxel51 Platform provides an interface through which you can upload and
+manage data for your application users and run jobs that process their data
+through the video understanding algorithms deployed on the Voxel51 Platform.
+
+In particular, the API exposes routes to manage your application, including
+uploading custom analytics, creating and managing users, monitoring the status
+of jobs, etc.
+
+This document provides a brief overview of using the Python Client Library
+to operate your application on the Voxel51 Platform.
+
+<img src="https://drive.google.com/uc?id=1j0S8pLsopAqF1Ik3rf-CdyAIU4kA0sOP" alt="voxel51-logo.png" width="40%"/>
+
+
+## Documentation
+
+See the [Applications Documentation](https://voxel51.com/docs/applications) for
+detailed documentation on using this client library to operate your application
+on the Voxel51 Platform.
+
+
+## Quickstart
+
+### Sign-up and Authentication
+
+To use the API with your application, you must first login to your application
+admin account at https://console.voxel51.com/admin and create an API token
+for your application.
+
+> Keep your application API token private; it is your access key to the API.
+
+Each API request you make must be authenticated by your application token. To
+activate your application token, set the `VOXEL51_APP_TOKEN` environment
+variable in your shell to point to your API token file:
+
+```shell
+export VOXEL51_APP_TOKEN="/path/to/your/app-token.json"
+```
+
+Alternatively, you can permanently activate an application token by executing
+the following commands:
+
+```py
+from voxel51.apps.auth import activate_application_token
+
+activate_application_token("/path/to/your/app-token.json")
+```
+
+In the latter case, your token is copied to `~/.voxel51/` and will be
+automatically used in all future sessions. An application token can be
+deactivated via the `voxel51.apps.auth.deactivate_application_token()` method.
+
+After you have activated an application API token, you have full access to the
+API.
+
+### Creating an Application API Session
+
+To initialize an API session for your application, issue the following
+commands:
+
+```py
+from voxel51.apps.api import ApplicationAPI
+
+api = ApplicationAPI()
+```
+
+### User Management
+
+The application API provides methods to manage the users of your application.
+
+For example, you can list the current users of your application:
+
+```py
+usernames = api.list_users()
+```
+
+and create a new user:
+
+```py
+api.create_user("<username>")
+```
+
+### Performing User Actions
+
+To perform actions for a user of your application, you must first activate the
+user:
+
+```py
+# Activate an application user
+api.with_user("<username>")
+```
+
+With a user activated, all subsequent API requests will be applied to that
+user. To deactivate the user, use the `ApplicationAPI.exit_user()` method.
+
+For example, you can upload data for the user:
+
+```py
+# Local path to the data
+data_path = "/path/to/video.mp4"
+
+api.upload_data(data_path)
+```
+
+And run a job on the user's data:
+
+```py
+from voxel51.users.jobs import JobRequest
+
+job_request = JobRequest("<analytic>")
+job_request.set_input("<input>", data_id="<data-id>")
+job_request.set_parameter("<parameter>", val)
+api.upload_job_request(job_request, "<job-name>", auto_start=True)
+```
+
+
+## Copyright
+
+Copyright 2017-2019, Voxel51, Inc.<br>
+[voxel51.com](https://voxel51.com)

--- a/CLI.md
+++ b/CLI.md
@@ -60,7 +60,861 @@ After you have activated an API token, you have full access to the API.
 The following usage information was generated via `voxel51 --all-help`:
 
 ```
+*******************************************************************************
+usage: voxel51 [-h] [-v] [--all-help] {auth,data,jobs,analytics,status} ...
 
+Voxel51 Platform API command-line interface.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --version         show version info
+  --all-help            show help recurisvely and exit
+
+available commands:
+  {auth,data,jobs,analytics,status}
+    auth                Tools for configuring API tokens.
+    data                Tools for working with data.
+    jobs                Tools for working with jobs.
+    analytics           Tools for working with analytics.
+    status              Tools for checking the status of the platform.
+
+
+*******************************************************************************
+usage: voxel51 auth [-h] [--all-help] {show,activate,deactivate} ...
+
+Tools for configuring API tokens.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --all-help            show help recurisvely and exit
+
+available commands:
+  {show,activate,deactivate}
+    show                Show info about the active API token.
+    activate            Activate an API token.
+    deactivate          Deletes the active API token, if any.
+
+
+*******************************************************************************
+usage: voxel51 auth show [-h]
+
+Show info about the active API token.
+
+    Examples:
+        # Print info about active token
+        voxel51 auth show
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+
+*******************************************************************************
+usage: voxel51 auth activate [-h] activate
+
+Activate an API token.
+
+    Examples:
+        # Activate API token
+        voxel51 auth activate '/path/to/token.json'
+
+positional arguments:
+  activate    path to API token to activate
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+
+*******************************************************************************
+usage: voxel51 auth deactivate [-h]
+
+Deletes the active API token, if any.
+
+optional arguments:
+  -h, --help  show this help message and exit
+
+
+*******************************************************************************
+usage: voxel51 data [-h] [--all-help]
+                    {list,info,upload,download,ttl,delete} ...
+
+Tools for working with data.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --all-help            show help recurisvely and exit
+
+available commands:
+  {list,info,upload,download,ttl,delete}
+    list                List data uploaded to the platform.
+    info                Get information about data uploaded to the platform.
+    upload              Upload data to the platform.
+    download            Download data from the platform.
+    ttl                 Update TTL of data on the platform.
+    delete              Delete data from the platform.
+
+
+*******************************************************************************
+usage: voxel51 data list [-h] [-l LIMIT] [-s SEARCH] [--sort-by FIELD]
+                         [--ascending] [-a] [-c]
+
+List data uploaded to the platform.
+
+    Examples:
+        # List data according to the given query
+        voxel51 data list
+            [--limit <limit>]
+            [--search [<field>:]<str>[,...]]
+            [--sort-by <field>]
+            [--ascending]
+            [--all-fields]
+            [--count]
+
+        # List the last 10 data uploaded to the platform
+        voxel51 data list --limit 10 --sort-by upload_date
+
+        # List data whose filenames contain "test", in ascending order of size
+        voxel51 data list --search name:test --sort-by size --ascending
+
+    Search syntax:
+        The generic search syntax is:
+
+            --search [<field>:]<str>[,...]
+
+        where:
+            <field>    an optional field name on which to search
+            <str>      the search string
+
+        The supported fields for data searches are `id`, `name`, and `type`.
+
+        If `<field>:` is omitted, the search will match any records for which
+        any field contains the given search string.
+
+        Multiple searches can be specified as a comma-separated list. Records
+        must match all searches in order to appear in the search results.
+
+        You can include special characters `,` and `:` in search strings by
+        escaping them with `\`.
+
+        Fields are case insensitive, and underscores can be used in-place of
+        spaces.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -l LIMIT, --limit LIMIT
+                        limit the number of data listed
+  -s SEARCH, --search SEARCH
+                        search to limit results when listing data
+  --sort-by FIELD       field to sort by when listing data
+  --ascending           whether to sort in ascending order
+  -a, --all-fields      whether to print all available fields
+  -c, --count           whether to show the number of data in the list
+
+
+*******************************************************************************
+usage: voxel51 data info [-h] [-a] ID [ID ...]
+
+Get information about data uploaded to the platform.
+
+    Examples:
+        # Get data info
+        voxel51 data info <id> [...]
+
+        # Get all available fields for data
+        voxel51 data info --all-fields <id> [...]
+
+positional arguments:
+  ID                the data ID(s) of interest
+
+optional arguments:
+  -h, --help        show this help message and exit
+  -a, --all-fields  whether to print all available fields
+
+
+*******************************************************************************
+usage: voxel51 data upload [-h] [--print-id] PATH [PATH ...]
+
+Upload data to the platform.
+
+    Examples:
+        # Upload data
+        voxel51 data upload '/path/to/video.mp4' [...]
+
+positional arguments:
+  PATH        the file(s) to upload
+
+optional arguments:
+  -h, --help  show this help message and exit
+  --print-id  whether to print only the ID(s) of the uploaded data
+
+
+*******************************************************************************
+usage: voxel51 data download [-h] [-p PATH] [-u ID] ID
+
+Download data from the platform.
+
+    Examples:
+        # Download data to default location
+        voxel51 data download <id>
+
+        # Download data to specific location
+        voxel51 data download <id> --path '/path/for/video.mp4'
+
+        # Generate signed URL to download data
+        voxel51 data download <id> --url
+
+positional arguments:
+  ID                    data to download
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PATH, --path PATH  path to download data
+  -u ID, --url ID       generate signed URL to download data
+
+
+*******************************************************************************
+usage: voxel51 data ttl [-h] [--days DAYS] [--date DATE] [-a] [-f] [--dry-run]
+                        [ID [ID ...]]
+
+Update TTL of data on the platform.
+
+    Examples:
+        # Extend TTL of data by specified number of days
+        voxel51 data ttl --days <days> <id> [...]
+
+        # Set expiration date of data to given date
+        voxel51 data ttl --date <date> <id> [...]
+
+positional arguments:
+  ID           the data ID(s) to update
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --days DAYS  the number of days by which to extend the TTL of the data
+  --date DATE  new expiration date for the data
+  -a, --all    whether to update all data
+  -f, --force  whether to force update all without confirmation
+  --dry-run    whether to print data IDs that would be updated rather than actually performing the action
+
+
+*******************************************************************************
+usage: voxel51 data delete [-h] [-a] [-f] [--dry-run] [ID [ID ...]]
+
+Delete data from the platform.
+
+    Examples:
+        # Delete data
+        voxel51 data delete <id> [...]
+
+        # Delete all data
+        voxel51 data delete --all
+
+positional arguments:
+  ID           the data ID(s) to delete
+
+optional arguments:
+  -h, --help   show this help message and exit
+  -a, --all    whether to delete all data
+  -f, --force  whether to force delete all without confirmation
+  --dry-run    whether to print data IDs that would be deleted rather than actually performing the action
+
+
+*******************************************************************************
+usage: voxel51 jobs [-h] [--all-help]
+                    {list,info,upload,start,archive,unarchive,ttl,request,status,log,download,kill,delete}
+                    ...
+
+Tools for working with jobs.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --all-help            show help recurisvely and exit
+
+available commands:
+  {list,info,upload,start,archive,unarchive,ttl,request,status,log,download,kill,delete}
+    list                List jobs on the platform.
+    info                Get information about jobs on the platform.
+    upload              Upload job requests to the platform.
+    start               Start jobs on the platform.
+    archive             Archive jobs on the platform.
+    unarchive           Unarchive jobs on the platform.
+    ttl                 Update TTL of jobs on the platform.
+    request             Download job requests.
+    status              Download job statuses.
+    log                 Download job logfiles.
+    download            Download job outputs.
+    kill                Kill jobs on the platform.
+    delete              Delete jobs on the platform.
+
+
+*******************************************************************************
+usage: voxel51 jobs list [-h] [-l LIMIT] [-s SEARCH] [--sort-by FIELD]
+                         [--ascending] [-a] [-c] [--ready] [--queued]
+                         [--scheduled] [--running] [--complete] [--failed]
+                         [--include-archived] [--exclude-archived]
+                         [--archived-only] [--include-expired]
+                         [--exclude-expired] [--expired-only]
+
+List jobs on the platform.
+
+    Notes:
+        Unless overridden, only unarchived jobs are listed.
+
+    Examples:
+        # List jobs according to the given query
+        voxel51 jobs list
+            [--limit <limit>]
+            [--search [<field>:]<str>[,...]]
+            [--sort-by <field>]
+            [--ascending]
+            [--all-fields]
+            [--count]
+
+        # Flags for jobs in a particular state
+        voxel51 jobs list --ready
+        voxel51 jobs list --queued
+        voxel51 jobs list --scheduled
+        voxel51 jobs list --running
+        voxel51 jobs list --complete
+        voxel51 jobs list --failed
+
+        # Flags for jobs with a particular archival state
+        # These flags are ignored when a search containing `archived` is found
+        voxel51 jobs list --include-archived
+        voxel51 jobs list --exclude-archived    (default behavior)
+        voxel51 jobs list --archived-only
+
+        # Flags for jobs with a particular expiration status
+        voxel51 jobs list --include-expired     (default behavior)
+        voxel51 jobs list --exclude-expired
+        voxel51 jobs list --expired-only
+
+        # List the last 10 jobs completed on the platform
+        voxel51 jobs list --complete --limit 10 --sort-by upload_date
+
+        # List jobs whose filenames contain "test", in alphabetical order
+        voxel51 jobs list --search name:test --sort-by name --ascending
+
+    Search syntax:
+        The generic search syntax is:
+
+            --search [<field>:]<str>[,...]
+
+        where:
+            <field>    an optional field name on which to search
+            <str>      the search string
+
+        The supported fields for jobs searches are `id`, `name`, `state`, and
+        `archived`.
+
+        If `<field>:` is omitted, the search will match any records for which
+        any field contains the given search string.
+
+        Multiple searches can be specified as a comma-separated list. Records
+        must match all searches in order to appear in the search results.
+
+        You can include special characters `,` and `:` in search strings by
+        escaping them with `\`.
+
+        Fields are case insensitive, and underscores can be used in-place of
+        spaces.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -l LIMIT, --limit LIMIT
+                        limit the number of jobs listed
+  -s SEARCH, --search SEARCH
+                        search to limit results when listing jobs
+  --sort-by FIELD       field to sort by when listing jobs
+  --ascending           whether to sort in ascending order
+  -a, --all-fields      whether to print all available fields
+  -c, --count           whether to show the number of jobs in the list
+
+state arguments:
+  --ready               jobs in READY state
+  --queued              jobs in QUEUED state
+  --scheduled           jobs in SCHEDULED state
+  --running             jobs in RUNNING state
+  --complete            jobs in COMPLETE state
+  --failed              jobs in FAILED state
+
+archival arguments:
+  --include-archived    include archived jobs
+  --exclude-archived    exclude archived jobs (default behavior)
+  --archived-only       only archived jobs
+
+expiration arguments:
+  --include-expired     include expired jobs (default behavior)
+  --exclude-expired     exclude expired jobs
+  --expired-only        only expired jobs
+
+
+*******************************************************************************
+usage: voxel51 jobs info [-h] [-a] ID [ID ...]
+
+Get information about jobs on the platform.
+
+    Examples:
+        # Get job(s) info
+        voxel51 jobs info <id> [...]
+
+        # Get all available fields for jobs
+        voxel51 jobs info --all-fields <id> [...]
+
+positional arguments:
+  ID                the job ID(s) of interest
+
+optional arguments:
+  -h, --help        show this help message and exit
+  -a, --all-fields  whether to print all available fields
+
+
+*******************************************************************************
+usage: voxel51 jobs upload [-h] [-n NAME] [--auto-start] [--print-id] PATH
+
+Upload job requests to the platform.
+
+    Examples:
+        # Upload job request
+        voxel51 jobs upload '/path/to/request.json'
+            --name <job-name> [--auto-start]
+
+positional arguments:
+  PATH                  job request to upload
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -n NAME, --name NAME  job name
+  --auto-start          whether to automatically start job
+  --print-id            whether to print only the ID(s) of the job
+
+
+*******************************************************************************
+usage: voxel51 jobs start [-h] [-a] [-f] [--dry-run] [ID [ID ...]]
+
+Start jobs on the platform.
+
+    Examples:
+        # Start specific jobs
+        voxel51 jobs start <id> [...]
+
+        # Start all eligible (unstarted) jobs
+        voxel51 jobs start --all
+
+positional arguments:
+  ID           the job ID(s) to start
+
+optional arguments:
+  -h, --help   show this help message and exit
+  -a, --all    whether to start all eligible (unstarted) jobs
+  -f, --force  whether to force start all without confirmation
+  --dry-run    whether to print job IDs that would be started rather than actually performing the action
+
+
+*******************************************************************************
+usage: voxel51 jobs archive [-h] [-a] [-f] [--dry-run] [ID [ID ...]]
+
+Archive jobs on the platform.
+
+    Examples:
+        # Archive specific jobs
+        voxel51 jobs archive <id> [...]
+
+        # Archive all jobs
+        voxel51 jobs archive --all
+
+positional arguments:
+  ID           the job ID(s) to archive
+
+optional arguments:
+  -h, --help   show this help message and exit
+  -a, --all    whether to archive all jobs
+  -f, --force  whether to force archive all without confirmation
+  --dry-run    whether to print job IDs that would be archived rather than actually performing the action
+
+
+*******************************************************************************
+usage: voxel51 jobs unarchive [-h] [-a] [-f] [--dry-run] [ID [ID ...]]
+
+Unarchive jobs on the platform.
+
+    Examples:
+        # Unarchive specific jobs
+        voxel51 jobs unarchive <id> [...]
+
+        # Unarchive all eligible (unexpired) jobs
+        voxel51 jobs unarchive --all
+
+positional arguments:
+  ID           the job ID(s) to unarchive
+
+optional arguments:
+  -h, --help   show this help message and exit
+  -a, --all    whether to unarchive all eligible (unexpired) jobs
+  -f, --force  whether to force unarchive all without confirmation
+  --dry-run    whether to print job IDs that would be unarchived rather than actually performing the action
+
+
+*******************************************************************************
+usage: voxel51 jobs ttl [-h] [--days DAYS] [--date DATE] [-a] [-f] [--dry-run]
+                        [ID [ID ...]]
+
+Update TTL of jobs on the platform.
+
+    Examples:
+        # Extend TTL of jobs by given number of days
+        voxel51 jobs ttl --days <days> <id> [...]
+
+        # Set expiration date of jobs to given date
+        voxel51 jobs ttl --date <date> <id> [...]
+
+positional arguments:
+  ID           the job ID(s) to update
+
+optional arguments:
+  -h, --help   show this help message and exit
+  --days DAYS  the number of days by which to extend the TTL of the jobs
+  --date DATE  new expiration date for the jobs
+  -a, --all    whether to update all eligible (unexpired) jobs
+  -f, --force  whether to force update all without confirmation
+  --dry-run    whether to print job IDs that would be updated rather than actually performing the action
+
+
+*******************************************************************************
+usage: voxel51 jobs request [-h] [-p PATH] ID
+
+Download job requests.
+
+    Example:
+        # Print job request
+        voxel51 jobs request <id>
+
+        # Download job request to disk
+        voxel51 jobs request <id> --path '/path/for/request.json'
+
+positional arguments:
+  ID                    the job ID of interest
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PATH, --path PATH  path to write request JSON
+
+
+*******************************************************************************
+usage: voxel51 jobs status [-h] [-p PATH] ID
+
+Download job statuses.
+
+    Example:
+        # Print job status
+        voxel51 jobs status <id>
+
+        # Download job status to disk
+        voxel51 jobs status <id> --path '/path/for/status.json'
+
+positional arguments:
+  ID                    the job ID of interest
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PATH, --path PATH  path to write status JSON
+
+
+*******************************************************************************
+usage: voxel51 jobs log [-h] [-p PATH] ID
+
+Download job logfiles.
+
+    Example:
+        # Print job logfile
+        voxel51 jobs log <id>
+
+        # Download job logfile to disk
+        voxel51 jobs log <id> --path '/path/for/job.log'
+
+positional arguments:
+  ID                    the job ID of interest
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PATH, --path PATH  path to write logfile
+
+
+*******************************************************************************
+usage: voxel51 jobs download [-h] [-p PATH] [-u ID] ID
+
+Download job outputs.
+
+    Examples:
+        # Download job output to default location
+        voxel51 jobs download <id>
+
+        # Download job output to specific location
+        voxel51 jobs download <id> --path '/path/for/job/output.json'
+
+        # Generate signed URL to download job output
+        voxel51 jobs download <id> --url
+
+positional arguments:
+  ID                    job output to download
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PATH, --path PATH  path to write output
+  -u ID, --url ID       generate signed URL to download job output
+
+
+*******************************************************************************
+usage: voxel51 jobs kill [-h] [-a] [-f] [--dry-run] [ID [ID ...]]
+
+Kill jobs on the platform.
+
+    Examples:
+        # Kill specific jobs
+        voxel51 jobs kill <id> [...]
+
+        # Kill all eligible (queued or scheduled) jobs
+        voxel51 jobs kill --all
+
+positional arguments:
+  ID           job ID(s) to kill
+
+optional arguments:
+  -h, --help   show this help message and exit
+  -a, --all    whether to kill all eligible (queued or scheduled) jobs
+  -f, --force  whether to force kill all without confirmation
+  --dry-run    whether to print job IDs that would be killed rather than actually performing the action
+
+
+*******************************************************************************
+usage: voxel51 jobs delete [-h] [-a] [-f] [--dry-run] [ID [ID ...]]
+
+Delete jobs on the platform.
+
+    Examples:
+        # Delete specific jobs
+        voxel51 jobs delete <id> [...]
+
+        # Delete all eligible (unstarted) jobs
+        voxel51 jobs delete --all
+
+positional arguments:
+  ID           job ID(s) to delete
+
+optional arguments:
+  -h, --help   show this help message and exit
+  -a, --all    whether to delete all eligible (unstarted) jobs
+  -f, --force  whether to force delete all without confirmation
+  --dry-run    whether to print job IDs that would be deleted rather than actually performing the action
+
+
+*******************************************************************************
+usage: voxel51 analytics [-h] [--all-help] {list,info,doc,upload,delete} ...
+
+Tools for working with analytics.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --all-help            show help recurisvely and exit
+
+available commands:
+  {list,info,doc,upload,delete}
+    list                List analytics on the platform.
+    info                Get information about analytics on the platform.
+    doc                 Get documentation about analytics.
+    upload              Upload analytics to the platform.
+    delete              Delete analytics from the platform.
+
+
+*******************************************************************************
+usage: voxel51 analytics list [-h] [-l LIMIT] [-s SEARCH] [--sort-by FIELD]
+                              [--ascending] [--all-versions] [-a] [-c]
+                              [--public] [--user] [--include-pending]
+                              [--exclude-pending] [--pending-only]
+
+List analytics on the platform.
+
+    Notes:
+        Unless overridden, only the latest version of each analytic is listed,
+        and pending analytics are included.
+
+    Examples:
+        # List analytics according to the given query
+        voxel51 analytics list
+            [--limit <limit>]
+            [--search [<field>:]<str>[,...]]
+            [--sort-by <field>]
+            [--ascending]
+            [--all-versions]
+            [--all-fields]
+            [--count]
+
+        # Flags for analytics with particular scopes
+        voxel51 analytics list --public
+        voxel51 analytics list --user
+
+        # Flags for analytics with particular pending states
+        # These flags are ignored when a search containing `pending` is found
+        voxel51 analytics list --include-pending    (default behavior)
+        voxel51 analytics list --exclude-pending
+        voxel51 analytics list --only-pending
+
+        # List the last 10 analytics of any version uploaded to the platform
+        voxel51 analytics list --all-versions --limit 10 --sort-by upload_date
+
+        # List public analytics whose names contain "sense"
+        voxel51 analytics list --public --search name:sense
+
+    Search syntax:
+        The generic search syntax is:
+
+            --search [<field>:]<str>[,...]
+
+        where:
+            <field>    an optional field name on which to search
+            <str>      the search string
+
+        The supported fields for analytics searches are `id`, `name`, `version`
+        and `type`.
+
+        If `<field>:` is omitted, the search will match any records for which
+        any field contains the given search string.
+
+        Multiple searches can be specified as a comma-separated list. Records
+        must match all searches in order to appear in the search results.
+
+        You can include special characters `,` and `:` in search strings by
+        escaping them with `\`.
+
+        Fields are case insensitive, and underscores can be used in-place of
+        spaces.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -l LIMIT, --limit LIMIT
+                        limit the number of analytics listed
+  -s SEARCH, --search SEARCH
+                        search to limit results when listing analytics
+  --sort-by FIELD       field to sort by when listing analytics
+  --ascending           whether to sort in ascending order
+  --all-versions        whether to include all versions of analytics
+  -a, --all-fields      whether to print all available fields
+  -c, --count           whether to show the number of analytics in the list
+
+scope arguments:
+  --public              public analytics
+  --user                user analytics
+
+pending arguments:
+  --include-pending     include pending analytics (default behavior)
+  --exclude-pending     exclude pending analytics
+  --pending-only        only pending analytics
+
+
+*******************************************************************************
+usage: voxel51 analytics info [-h] [-a] ID [ID ...]
+
+Get information about analytics on the platform.
+
+    Examples:
+        # Get analytic(s) info
+        voxel51 analytics info <id> [...]
+
+        # Get all available fields for analytics
+        voxel51 analytics info --all-fields <id> [...]
+
+positional arguments:
+  ID                the analytic ID(s) of interest
+
+optional arguments:
+  -h, --help        show this help message and exit
+  -a, --all-fields  whether to print all available fields
+
+
+*******************************************************************************
+usage: voxel51 analytics doc [-h] [-p PATH] ID
+
+Get documentation about analytics.
+
+    Examples:
+        # Print documentation for analytic
+        voxel51 analytics doc <id>
+
+        # Write documentation for analytic to disk
+        voxel51 analytics doc <id> --path '/path/for/doc.json'
+
+positional arguments:
+  ID                    the analytic ID
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -p PATH, --path PATH  path to write doc JSON
+
+
+*******************************************************************************
+usage: voxel51 analytics upload [-h] [--doc PATH]
+                                [--analytic-type ANALYTIC_TYPE] [--image ID]
+                                [--path PATH] [--image-type IMAGE_TYPE]
+                                [--print-id]
+
+Upload analytics to the platform.
+
+    Examples:
+        # Upload documentation for analytic
+        voxel51 analytics upload --doc '/path/to/doc.json'
+            [--analytic-type TYPE]
+
+        # Upload analytic image
+        voxel51 analytics upload --image <id>
+            --path '/path/to/image.tar.gz' --image-type cpu|gpu
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --doc PATH            analytic documentation to upload
+  --analytic-type ANALYTIC_TYPE
+                        type of analytic
+  --image ID            analytic ID to upload image for
+  --path PATH           analytic image to upload
+  --image-type IMAGE_TYPE
+                        type of image being uploaded
+  --print-id            whether to print only the ID of the uploaded analytic
+
+
+*******************************************************************************
+usage: voxel51 analytics delete [-h] [-f] ID [ID ...]
+
+Delete analytics from the platform.
+
+    Example:
+        # Delete analytics
+        voxel51 analytics delete <id> [...]
+
+positional arguments:
+  ID           the analytic ID(s) to delete
+
+optional arguments:
+  -h, --help   show this help message and exit
+  -f, --force  whether to force delete without confirmation
+
+
+*******************************************************************************
+usage: voxel51 status [-h] [-p] [-j]
+
+Tools for checking the status of the platform.
+
+    Examples:
+        # Check status of all platform services
+        voxel51 status
+
+        # Check whether platform is up
+        voxel51 status --platform
+
+        # Check whether jobs cluster is up
+        voxel51 status --jobs-cluster
+
+optional arguments:
+  -h, --help          show this help message and exit
+  -p, --platform      check if platform is up
+  -j, --jobs-cluster  check if jobs cluster is up
 ```
 
 

--- a/CLI.md
+++ b/CLI.md
@@ -1,4 +1,4 @@
-# Voxel51 Platform API Command-Line Interface Quickstart
+# Command-Line Interface Quickstart
 
 Installing the Python Client Library automatically installs `voxel51`, a
 command-line interface (CLI) for interacting with the Voxel51 Platform.

--- a/CLI.md
+++ b/CLI.md
@@ -248,7 +248,7 @@ optional arguments:
 
 
 *******************************************************************************
-usage: voxel51 data download [-h] [-p PATH] [-u ID] ID
+usage: voxel51 data download [-h] [-p PATH] [-u] ID
 
 Download data from the platform.
 
@@ -268,7 +268,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -p PATH, --path PATH  path to download data
-  -u ID, --url ID       generate signed URL to download data
+  -u, --url             generate signed URL to download data
 
 
 *******************************************************************************
@@ -620,7 +620,7 @@ optional arguments:
 
 
 *******************************************************************************
-usage: voxel51 jobs log [-h] [-p PATH] ID
+usage: voxel51 jobs log [-h] [-p PATH] [-u] ID
 
 Download job logfiles.
 
@@ -631,16 +631,20 @@ Download job logfiles.
         # Download job logfile to disk
         voxel51 jobs log <id> --path '/path/for/job.log'
 
+        # Generate signed URL to download job logfile
+        voxel51 jobs log <id> --url
+
 positional arguments:
   ID                    the job ID of interest
 
 optional arguments:
   -h, --help            show this help message and exit
   -p PATH, --path PATH  path to write logfile
+  -u, --url             generate signed URL to download job logfile
 
 
 *******************************************************************************
-usage: voxel51 jobs download [-h] [-p PATH] [-u ID] ID
+usage: voxel51 jobs download [-h] [-p PATH] [-u] ID
 
 Download job outputs.
 
@@ -660,7 +664,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   -p PATH, --path PATH  path to write output
-  -u ID, --url ID       generate signed URL to download job output
+  -u, --url             generate signed URL to download job output
 
 
 *******************************************************************************

--- a/CLI.md
+++ b/CLI.md
@@ -55,27 +55,6 @@ A token can be deactivated via `voxel51 auth deactivate`.
 After you have activated an API token, you have full access to the API.
 
 
-## Usage
-
-```
-$ voxel51 --help
-usage: voxel51 [-h] [-v] {auth,data,jobs,analytics} ...
-
-Voxel51 Platform API command-line interface.
-
-optional arguments:
-  -h, --help            show this help message and exit
-  -v, --version         show version info
-
-available commands:
-  {auth,data,jobs,analytics}
-    auth                Tools for configuring API tokens.
-    data                Tools for working with data.
-    jobs                Tools for working with jobs.
-    analytics           Tools for working with analytics.
-```
-
-
 ## Copyright
 
 Copyright 2017-2019, Voxel51, Inc.<br>

--- a/CLI.md
+++ b/CLI.md
@@ -55,6 +55,15 @@ A token can be deactivated via `voxel51 auth deactivate`.
 After you have activated an API token, you have full access to the API.
 
 
+## Usage
+
+The following usage information was generated via `voxel51 --all-help`:
+
+```
+
+```
+
+
 ## Copyright
 
 Copyright 2017-2019, Voxel51, Inc.<br>

--- a/CLI.md
+++ b/CLI.md
@@ -1,0 +1,82 @@
+# Voxel51 Platform API Command-Line Interface Quickstart
+
+Installing the Python Client Library automatically installs `voxel51`, a
+command-line interface (CLI) for interacting with the Voxel51 Platform.
+
+This document provides a brief overview of using the CLI.
+
+<img src="https://drive.google.com/uc?id=1j0S8pLsopAqF1Ik3rf-CdyAIU4kA0sOP" alt="voxel51-logo.png" width="40%"/>
+
+
+## Documentation
+
+For full documentation of using the CLI, see the
+[API Documentation](https://voxel51.com/docs/api).
+
+For end-to-end examples of using the CLI to create and run jobs on the Voxel51
+Platform, see the
+[Analytics Documentation](https://voxel51.com/docs/analytics).
+
+
+## Quickstart
+
+To use the CLI, you must activate an API token. You can do so either by
+setting the `VOXEL51_API_TOKEN` environment variable in your shell to point
+to your API token file:
+
+```shell
+export VOXEL51_API_TOKEN=/path/to/your/api-token.json
+```
+
+Alternatively, you can permanently activate a token by executing the following
+commands:
+
+```shell
+voxel51 auth activate /path/to/your/api-token.json
+```
+
+In the latter case, your token is copied to `~/.voxel51/` and will be
+automatically used in all future sessions.
+
+To show information about your active token, you can execute:
+
+```shell
+$ voxel51 auth show
+API token
+-------------  ------------------------------------
+id             2649113c-e5ca-4008-a2f3-a24a9db806b9
+creation date  2018-11-30 01:12:28 EST
+base api url   https://api.voxel51.com
+path           /path/to/your/api-token.json
+```
+
+A token can be deactivated via `voxel51 auth deactivate`.
+
+After you have activated an API token, you have full access to the API.
+
+
+## Usage
+
+```
+$ voxel51 --help
+usage: voxel51 [-h] [-v] {auth,data,jobs,analytics} ...
+
+Voxel51 Platform API command-line interface.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -v, --version         show version info
+
+available commands:
+  {auth,data,jobs,analytics}
+    auth                Tools for configuring API tokens.
+    data                Tools for working with data.
+    jobs                Tools for working with jobs.
+    analytics           Tools for working with analytics.
+```
+
+
+## Copyright
+
+Copyright 2017-2019, Voxel51, Inc.<br>
+[voxel51.com](https://voxel51.com)

--- a/README.md
+++ b/README.md
@@ -137,26 +137,14 @@ print(job_request)
 Upload a job request:
 
 ```py
-api.upload_job_request(job_request, "<job-name>")
+metadata = api.upload_job_request(job_request, "<job-name>")
+job_id = metadata["id"]
 ```
 
 Start a job:
 
 ```py
-# ID of the job
-job_id = "XXXXXXXX"
-
 api.start_job(job_id)
-```
-
-Wait until a job is complete and then download its output:
-
-```py
-# Local path to which to download the output
-output_path = "/path/to/output.zip"
-
-api.wait_until_job_completes(job_id)
-api.download_job_output(job_id, output_path)
 ```
 
 Get the status of a job:
@@ -165,102 +153,13 @@ Get the status of a job:
 status = api.get_job_status(job_id)
 ```
 
-
-## Application Quickstart
-
-This section provides a brief guide to using the Platform API with your
-application.
-
-### Sign-up and Authentication
-
-To use the API with your application, you must first login to your application
-admin account at https://console.voxel51.com/admin and create an API token
-for your application.
-
-> Keep your application API token private; it is your access key to the API.
-
-Each API request you make must be authenticated by your application token. To
-activate your application token, set the `VOXEL51_APP_TOKEN` environment
-variable in your shell to point to your API token file:
-
-```shell
-export VOXEL51_APP_TOKEN="/path/to/your/app-token.json"
-```
-
-Alternatively, you can permanently activate an application token by executing
-the following commands:
+Download the output of a completed job:
 
 ```py
-from voxel51.apps.auth import activate_application_token
+# Local path to which to download the output
+output_path = "/path/to/labels.json"
 
-activate_application_token("/path/to/your/app-token.json")
-```
-
-In the latter case, your token is copied to `~/.voxel51/` and will be
-automatically used in all future sessions. An application token can be
-deactivated via the `voxel51.apps.auth.deactivate_application_token()` method.
-
-After you have activated an application API token, you have full access to the
-API.
-
-### Creating an Application API Session
-
-To initialize an API session for your application, issue the following
-commands:
-
-```py
-from voxel51.apps.api import ApplicationAPI
-
-api = ApplicationAPI()
-```
-
-### User Management
-
-The application API provides methods to manage the users of your application.
-
-For example, you can list the current users of your application:
-
-```py
-usernames = api.list_users()
-```
-
-and create a new user:
-
-```py
-api.create_user("<username>")
-```
-
-### Performing User Actions
-
-To perform actions for a user of your application, you must first activate the
-user:
-
-```py
-# Activate an application user
-api.with_user("<username>")
-```
-
-With a user activated, all subsequent API requests will be applied to that
-user. To deactivate the user, use the `api.exit_user()` method.
-
-For example, you can upload data for the user:
-
-```py
-# Local path to the data
-data_path = "/path/to/video.mp4"
-
-api.upload_data(data_path)
-```
-
-And run a job on the user's data:
-
-```py
-from voxel51.users.jobs import JobRequest
-
-job_request = JobRequest("<analytic>")
-job_request.set_input("<input>", data_id="<data-id>")
-job_request.set_parameter("<param>", val)
-api.upload_job_request(job_request, "<job-name>", auto_start=True)
+api.download_job_output(job_id, output_path=output_path)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ each of the analytics exposed on the Voxel51 Platform, see
 the [Analytics Documentation](https://voxel51.com/docs/analytics).
 
 For more information about using the `voxel51` command-line interface that is
-provided by this library see the [CLI Quickstart](CLI.md).
+provided by this library see the [CLI Quickstart](CLI).
 
 For more information about using the Python Client Library to operate an
 application on the Voxel51 Platform, see the
-[Applications Quickstart](APPLICATIONS.md).
+[Applications Quickstart](APPLICATIONS).
 
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ To learn how to use this client library to create and run jobs that execute
 each of the analytics exposed on the Voxel51 Platform, see
 the [Analytics Documentation](https://voxel51.com/docs/analytics).
 
+For more information about using the `voxel51` command-line interface that is
+provided by this library see the [CLI Quickstart](CLI.md).
+
+For more information about using the Python Client Library to operate an
+application on the Voxel51 Platform, see the
+[Applications Quickstart](APPLICATIONS.md).
+
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Voxel51 Platform API Python Client Library
 
-A Python client library for interacting with the Voxel51 Platform.
+A Python client library for the Voxel51 Platform.
 
-Available at [https://github.com/voxel51/api-py](https://github.com/voxel51/api-py).
+Available at
+[https://github.com/voxel51/api-py](https://github.com/voxel51/api-py).
 
 <img src="https://drive.google.com/uc?id=1j0S8pLsopAqF1Ik3rf-CdyAIU4kA0sOP" alt="voxel51-logo.png" width="40%"/>
 
@@ -13,12 +14,12 @@ To install the library, first clone it:
 
 ```shell
 git clone https://github.com/voxel51/api-py
-cd api-py
 ```
 
 and then run the install script:
 
 ```shell
+cd api-py
 bash install.bash
 ```
 
@@ -33,7 +34,7 @@ each of the analytics exposed on the Voxel51 Platform, see
 the [Analytics Documentation](https://voxel51.com/docs/analytics).
 
 
-## User Quickstart
+## Quickstart
 
 This section provides a brief guide to using the Platform API with your user
 account.
@@ -50,7 +51,7 @@ token, set the `VOXEL51_API_TOKEN` environment variable in your shell to point
 to your API token file:
 
 ```shell
-export VOXEL51_API_TOKEN="/path/to/your/api-token.json"
+export VOXEL51_API_TOKEN=/path/to/your/api-token.json
 ```
 
 Alternatively, you can permanently activate a token by executing the following
@@ -97,6 +98,12 @@ doc = api.get_analytic_doc(analytic_id)
 
 ### Data
 
+List uploaded data:
+
+```py
+data = api.list_data()
+```
+
 Upload data to the cloud storage:
 
 ```py
@@ -104,12 +111,6 @@ Upload data to the cloud storage:
 data_path = "/path/to/video.mp4"
 
 api.upload_data(data_path)
-```
-
-List uploaded data:
-
-```py
-data = api.list_data()
 ```
 
 ### Jobs
@@ -122,14 +123,14 @@ jobs = api.list_jobs()
 
 Create a job request to perform an analytic on a data, where `<analytic>` is
 the name of the analytic to run, `<data-id>` is the ID of the data to process,
-and any `<param>` values are set as necessary to configre the analytic:
+and any `<parameter>` values are set as necessary to configre the analytic:
 
 ```py
 from voxel51.users.jobs import JobRequest
 
 job_request = JobRequest("<analytic>")
 job_request.set_input("<input>", data_id="<data-id>")
-job_request.set_parameter("<param>", val)
+job_request.set_parameter("<parameter>", val)
 
 print(job_request)
 ```

--- a/README.md
+++ b/README.md
@@ -36,15 +36,14 @@ the [Analytics Documentation](https://voxel51.com/docs/analytics).
 For more information about using the `voxel51` command-line interface that is
 provided by this library see the [CLI Quickstart](CLI).
 
-For more information about using the Python Client Library to operate an
-application on the Voxel51 Platform, see the
-[Applications Quickstart](APPLICATIONS).
+For more information about using this client library to operate an application
+on the Voxel51 Platform, see the [Applications Quickstart](APPLICATIONS).
 
 
 ## Quickstart
 
-This section provides a brief guide to using the Platform API with your user
-account.
+This section provides a brief guide to using the Platform API with this client
+library.
 
 ### Sign-up and Authentication
 

--- a/docs/generate_docs.bash
+++ b/docs/generate_docs.bash
@@ -8,17 +8,48 @@
 # voxel51.com
 #
 
-echo "**** Generating documentation"
+SOURCE_DIR=docs/source
+BUILD_DIR=docs/build
+
+# Show usage information
+usage() {
+    echo "Usage:  bash $0 [-h] [-c]
+
+Getting help:
+-h      Display this help message.
+
+Build options:
+-c      Perform a clean build by first deleting any existing build directory.
+"
+}
+
+# Parse flags
+SHOW_HELP=false
+CLEAN_BUILD=false
+while getopts "hc" FLAG; do
+    case "${FLAG}" in
+        h) SHOW_HELP=true ;;
+        c) CLEAN_BUILD=true ;;
+        *) usage ;;
+    esac
+done
+[ ${SHOW_HELP} = true ] && usage && exit 0
+
+if [ ${CLEAN_BUILD} = true ]; then
+    echo "**** Deleting existing build directory, if necessary"
+    rm -rf ${BUILD_DIR}
+fi
 
 #
 # We exclude `voxel51/cli` from the generated docs, because the CLI is
 # self-documenting from the command-line
 #
-sphinx-apidoc -f -o docs/source voxel51 voxel51/cli
+echo "**** Generating documentation"
+sphinx-apidoc -f -o ${SOURCE_DIR} voxel51 voxel51/cli
 
 cd docs
 make html
 cd ..
 
 echo "**** Documentation complete"
-printf "To view the docs, run:\n\nopen docs/build/html/index.html\n\n"
+printf "To view the docs, run:\n\nopen ${BUILD_DIR}/html/index.html\n\n"

--- a/docs/source/APPLICATIONS.rst
+++ b/docs/source/APPLICATIONS.rst
@@ -1,0 +1,2 @@
+
+.. mdinclude:: ../../APPLICATIONS.md

--- a/docs/source/CLI.rst
+++ b/docs/source/CLI.rst
@@ -1,0 +1,2 @@
+
+.. mdinclude:: ../../CLI.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,4 +5,6 @@ Voxel51 Platform API Python Client Library
    :maxdepth: 2
 
    README
+   CLI
+   APPLICATIONS
    voxel51

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1657,6 +1657,9 @@ def _print_active_token_info():
 
 
 def _print_data_table(data, show_count=False, show_all_fields=False):
+    if show_count:
+        total_size = _render_bytes(sum(d["size"] for d in data))
+
     render_fcns = {
         "name": _render_name,
         "size": _render_bytes,
@@ -1675,8 +1678,7 @@ def _print_data_table(data, show_count=False, show_all_fields=False):
 
     print(table_str)
     if show_count:
-        total_size = _render_bytes(sum(d["size"] for d in data))
-        print("\nShowing %d data, %s\n" % (len(records), total_size))
+        print("\nShowing %d data, %s\n" % (len(data), total_size))
 
 
 def _print_data_uploads(uploads):
@@ -1703,7 +1705,7 @@ def _print_jobs_table(jobs, show_count=False, show_all_fields=False):
 
     print(table_str)
     if show_count:
-        print("\nShowing %d job(s)\n" % len(records))
+        print("\nShowing %d job(s)\n" % len(jobs))
 
 
 def _print_analytics_table(analytics, show_count=False, show_all_fields=False):
@@ -1726,7 +1728,7 @@ def _print_analytics_table(analytics, show_count=False, show_all_fields=False):
 
     print(table_str)
     if show_count:
-        print("\nFound %d analytic(s)\n" % len(records))
+        print("\nFound %d analytic(s)\n" % len(analytics))
 
 
 def _print_dict_as_json(d):

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1091,6 +1091,9 @@ class LogJobsCommand(Command):
 
         # Download job logfile to disk
         voxel51 jobs log <id> --path '/path/for/job.log'
+
+        # Generate signed URL to download job logfile
+        voxel51 jobs log <id> --url
     '''
 
     @staticmethod
@@ -1098,18 +1101,27 @@ class LogJobsCommand(Command):
         parser.add_argument("id", metavar="ID", help="the job ID of interest")
         parser.add_argument(
             "-p", "--path", metavar="PATH", help="path to write logfile")
+        parser.add_argument(
+            "-u", "--url", action="store_true",
+            help="generate signed URL to download job logfile")
 
     @staticmethod
     def run(parser, args):
         api = API()
 
+        if args.url:
+            url = api.get_job_logfile_download_url(args.id)
+            print(url)
+            return
+
         if args.path:
             api.download_job_logfile(args.id, output_path=args.path)
             print(
                 "Logfile for job '%s' written to '%s'" % (args.id, args.path))
-        else:
-            logfile = api.download_job_logfile(args.id, output_path=args.path)
-            print(logfile)
+            return
+
+        logfile = api.download_job_logfile(args.id, output_path=args.path)
+        print(logfile)
 
 
 class DownloadJobsCommand(Command):

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -333,7 +333,7 @@ class DownloadDataCommand(Command):
         parser.add_argument(
             "-p", "--path", metavar="PATH", help="path to download data")
         parser.add_argument(
-            "-u", "--url", metavar="ID",
+            "-u", "--url", action="store_true",
             help="generate signed URL to download data")
 
     @staticmethod
@@ -1133,7 +1133,7 @@ class DownloadJobsCommand(Command):
         parser.add_argument(
             "-p", "--path", metavar="PATH", help="path to write output")
         parser.add_argument(
-            "-u", "--url", metavar="ID",
+            "-u", "--url", action="store_true",
             help="generate signed URL to download job output")
 
     @staticmethod

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1736,7 +1736,8 @@ def _print_dict_as_json(d):
 
 def _print_dict_as_table(d):
     contents = list(d.items())
-    table_str = tabulate(contents, tablefmt="plain")
+    table_str = tabulate(
+        contents, headers=["Analytic", ""], tablefmt=TABLE_FORMAT)
     print(table_str)
 
 


### PR DESCRIPTION
To be reviewed after https://github.com/voxel51/api-py/pull/71, https://github.com/voxel51/api-py/pull/72, and https://github.com/voxel51/api-py/pull/73 are merged.

This PR adds a quickstart guide for using the CLI, and moves application-related information to a separate quickstart.

Also adds a `-c` option when generating the docs to perform a clean build.