### PR TITLE
Adding CLI support for posting data as URL, and clarifying analytic image upload

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -109,7 +109,7 @@ optional arguments:
 
 
 *******************************************************************************
-usage: voxel51 auth activate [-h] activate
+usage: voxel51 auth activate [-h] token
 
 Activate an API token.
 
@@ -118,7 +118,7 @@ Activate an API token.
         voxel51 auth activate '/path/to/token.json'
 
 positional arguments:
-  activate    path to API token to activate
+  token       path to API token to activate
 
 optional arguments:
   -h, --help  show this help message and exit
@@ -135,7 +135,7 @@ optional arguments:
 
 *******************************************************************************
 usage: voxel51 data [-h] [--all-help]
-                    {list,info,upload,download,ttl,delete} ...
+                    {list,info,upload,post-url,download,ttl,delete} ...
 
 Tools for working with data.
 
@@ -144,10 +144,11 @@ optional arguments:
   --all-help            show help recurisvely and exit
 
 available commands:
-  {list,info,upload,download,ttl,delete}
+  {list,info,upload,post-url,download,ttl,delete}
     list                List data uploaded to the platform.
     info                Get information about data uploaded to the platform.
     upload              Upload data to the platform.
+    post-url            Posts data via URL to the platform.
     download            Download data from the platform.
     ttl                 Update TTL of data on the platform.
     delete              Delete data from the platform.
@@ -161,12 +162,12 @@ List data uploaded to the platform.
 
     Examples:
         # List data according to the given query
-        voxel51 data list
-            [--limit <limit>]
-            [--search [<field>:]<str>[,...]]
-            [--sort-by <field>]
-            [--ascending]
-            [--all-fields]
+        voxel51 data list \
+            [--limit <limit>] \
+            [--search [<field>:]<str>[,...]] \
+            [--sort-by <field>] \
+            [--ascending] \
+            [--all-fields] \
             [--count]
 
         # List the last 10 data uploaded to the platform
@@ -245,6 +246,36 @@ positional arguments:
 optional arguments:
   -h, --help  show this help message and exit
   --print-id  whether to print only the ID(s) of the uploaded data
+
+
+*******************************************************************************
+usage: voxel51 data post-url [-h] -u URL -f NAME -m TYPE -s SIZE -e DATE
+                             [--print-id]
+
+Posts data via URL to the platform.
+
+    Examples:
+        # Post data via URL
+        voxel51 data post-url \
+            --url <url> \
+            --filename <filename> \
+            --mime-type <mime-type> \
+            --size <size-bytes> \
+            --expiration-date <expiration-date>
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --print-id            whether to print only the ID of the uploaded data
+
+required arguments:
+  -u URL, --url URL     the data URL
+  -f NAME, --filename NAME
+                        the data filename
+  -m TYPE, --mime-type TYPE
+                        the data MIME type
+  -s SIZE, --size SIZE  the data size, in bytes
+  -e DATE, --expiration-date DATE
+                        the data expiration date
 
 
 *******************************************************************************
@@ -361,12 +392,12 @@ List jobs on the platform.
 
     Examples:
         # List jobs according to the given query
-        voxel51 jobs list
-            [--limit <limit>]
-            [--search [<field>:]<str>[,...]]
-            [--sort-by <field>]
-            [--ascending]
-            [--all-fields]
+        voxel51 jobs list \
+            [--limit <limit>] \
+            [--search [<field>:]<str>[,...]] \
+            [--sort-by <field>] \
+            [--ascending] \
+            [--all-fields] \
             [--count]
 
         # Flags for jobs in a particular state
@@ -469,23 +500,24 @@ optional arguments:
 
 
 *******************************************************************************
-usage: voxel51 jobs upload [-h] [-n NAME] [--auto-start] [--print-id] PATH
+usage: voxel51 jobs upload [-h] -r PATH -n NAME [--auto-start] [--print-id]
 
 Upload job requests to the platform.
 
     Examples:
         # Upload job request
-        voxel51 jobs upload '/path/to/request.json'
+        voxel51 jobs upload --request '/path/to/request.json' \
             --name <job-name> [--auto-start]
-
-positional arguments:
-  PATH                  job request to upload
 
 optional arguments:
   -h, --help            show this help message and exit
-  -n NAME, --name NAME  job name
   --auto-start          whether to automatically start job
   --print-id            whether to print only the ID(s) of the job
+
+required arguments:
+  -r PATH, --request PATH
+                        path to job request to upload
+  -n NAME, --name NAME  job name
 
 
 *******************************************************************************
@@ -712,7 +744,8 @@ optional arguments:
 
 
 *******************************************************************************
-usage: voxel51 analytics [-h] [--all-help] {list,info,doc,upload,delete} ...
+usage: voxel51 analytics [-h] [--all-help]
+                         {list,info,doc,upload,upload-image,delete} ...
 
 Tools for working with analytics.
 
@@ -721,11 +754,12 @@ optional arguments:
   --all-help            show help recurisvely and exit
 
 available commands:
-  {list,info,doc,upload,delete}
+  {list,info,doc,upload,upload-image,delete}
     list                List analytics on the platform.
     info                Get information about analytics on the platform.
     doc                 Get documentation about analytics.
     upload              Upload analytics to the platform.
+    upload-image        Upload analytic images to the platform.
     delete              Delete analytics from the platform.
 
 
@@ -743,13 +777,13 @@ List analytics on the platform.
 
     Examples:
         # List analytics according to the given query
-        voxel51 analytics list
-            [--limit <limit>]
-            [--search [<field>:]<str>[,...]]
-            [--sort-by <field>]
-            [--ascending]
-            [--all-versions]
-            [--all-fields]
+        voxel51 analytics list \
+            [--limit <limit>] \
+            [--search [<field>:]<str>[,...]] \
+            [--sort-by <field>] \
+            [--ascending] \
+            [--all-versions] \
+            [--all-fields] \
             [--count]
 
         # Flags for analytics with particular scopes
@@ -855,32 +889,42 @@ optional arguments:
 
 
 *******************************************************************************
-usage: voxel51 analytics upload [-h] [--doc PATH]
-                                [--analytic-type ANALYTIC_TYPE] [--image ID]
-                                [--path PATH] [--image-type IMAGE_TYPE]
-                                [--print-id]
+usage: voxel51 analytics upload [-h] [-t ANALYTIC_TYPE] [--print-id] PATH
 
 Upload analytics to the platform.
 
     Examples:
-        # Upload documentation for analytic
-        voxel51 analytics upload --doc '/path/to/doc.json'
-            [--analytic-type TYPE]
+        # Upload analytic
+        voxel51 analytics upload '/path/to/doc.json' [--analytic-type TYPE]
 
-        # Upload analytic image
-        voxel51 analytics upload --image <id>
-            --path '/path/to/image.tar.gz' --image-type cpu|gpu
+positional arguments:
+  PATH                  analytic documentation
 
 optional arguments:
   -h, --help            show this help message and exit
-  --doc PATH            analytic documentation to upload
-  --analytic-type ANALYTIC_TYPE
-                        type of analytic
-  --image ID            analytic ID to upload image for
-  --path PATH           analytic image to upload
-  --image-type IMAGE_TYPE
-                        type of image being uploaded
+  -t ANALYTIC_TYPE, --analytic-type ANALYTIC_TYPE
+                        type of analytic (PLATFORM|IMAGE_TO_VIDEO). The default is PLATFORM
   --print-id            whether to print only the ID of the uploaded analytic
+
+
+*******************************************************************************
+usage: voxel51 analytics upload-image [-h] -i ID -p PATH -t TYPE
+
+Upload analytic images to the platform.
+
+    Examples:
+        # Upload image for analytic
+        voxel51 analytics upload-image \
+            --id <id> --path '/path/to/image.tar.gz' --image-type TYPE
+
+optional arguments:
+  -h, --help            show this help message and exit
+
+required arguments:
+  -i ID, --id ID        analytic ID
+  -p PATH, --path PATH  analytic image tarfile to upload
+  -t TYPE, --image-type TYPE
+                        type of image (CPU|GPU)
 
 
 *******************************************************************************

--- a/pylintrc
+++ b/pylintrc
@@ -66,7 +66,8 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 #disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
-disable=too-few-public-methods,too-many-instance-attributes,too-many-arguments,too-many-locals,too-many-lines,non-iterator-returned,too-many-statements
+
+disable=too-few-public-methods,too-many-instance-attributes,too-many-arguments,too-many-locals,too-many-lines,non-iterator-returned,too-many-statements,useless-object-inheritance,abstract-method,too-many-ancestors,too-many-branches
 
 
 [REPORTS]

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -234,7 +234,7 @@ class ApplicationAPI(API):
         '''
         endpoint = voxu.urljoin(
             self.base_url, "apps", "analytics", analytic_id, "images")
-        params = {"type": image_type.lower()}
+        params = {"type": image_type}
         filename = os.path.basename(image_tar_path)
         mime_type = _get_mime_type(image_tar_path)
         with open(image_tar_path, "rb") as df:

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -35,8 +35,8 @@ from voxel51.users.query import AnalyticsQuery, DataQuery, JobsQuery
 import voxel51.users.utils as voxu
 
 
-MAX_NAME_COLUMN_WIDTH = 51
-TABLE_FORMAT = "simple"
+_MAX_NAME_COLUMN_WIDTH = 51
+_TABLE_FORMAT = "simple"
 
 
 class Command(object):
@@ -127,12 +127,11 @@ class ActivateAuthCommand(Command):
 
     @staticmethod
     def setup(parser):
-        parser.add_argument(
-            "activate", help="path to API token to activate")
+        parser.add_argument("token", help="path to API token to activate")
 
     @staticmethod
     def run(parser, args):
-        voxa.activate_token(args.activate)
+        voxa.activate_token(args.token)
 
 
 class DeactivateAuthCommand(Command):
@@ -171,12 +170,12 @@ class ListDataCommand(Command):
 
     Examples:
         # List data according to the given query
-        voxel51 data list
-            [--limit <limit>]
-            [--search [<field>:]<str>[,...]]
-            [--sort-by <field>]
-            [--ascending]
-            [--all-fields]
+        voxel51 data list \\
+            [--limit <limit>] \\
+            [--search [<field>:]<str>[,...]] \\
+            [--sort-by <field>] \\
+            [--ascending] \\
+            [--all-fields] \\
             [--count]
 
         # List the last 10 data uploaded to the platform
@@ -565,12 +564,12 @@ class ListJobsCommand(Command):
 
     Examples:
         # List jobs according to the given query
-        voxel51 jobs list
-            [--limit <limit>]
-            [--search [<field>:]<str>[,...]]
-            [--sort-by <field>]
-            [--ascending]
-            [--all-fields]
+        voxel51 jobs list \\
+            [--limit <limit>] \\
+            [--search [<field>:]<str>[,...]] \\
+            [--sort-by <field>] \\
+            [--ascending] \\
+            [--all-fields] \\
             [--count]
 
         # Flags for jobs in a particular state
@@ -1371,13 +1370,13 @@ class ListAnalyticsCommand(Command):
 
     Examples:
         # List analytics according to the given query
-        voxel51 analytics list
-            [--limit <limit>]
-            [--search [<field>:]<str>[,...]]
-            [--sort-by <field>]
-            [--ascending]
-            [--all-versions]
-            [--all-fields]
+        voxel51 analytics list \\
+            [--limit <limit>] \\
+            [--search [<field>:]<str>[,...]] \\
+            [--sort-by <field>] \\
+            [--ascending] \\
+            [--all-versions] \\
+            [--all-fields] \\
             [--count]
 
         # Flags for analytics with particular scopes
@@ -1700,7 +1699,7 @@ def _print_platform_status_info(status, token):
 
     table_str = tabulate(
         records, headers=["service", "operational", "message"],
-        tablefmt=TABLE_FORMAT)
+        tablefmt=_TABLE_FORMAT)
     print(table_str)
 
 
@@ -1714,7 +1713,7 @@ def _print_active_token_info():
         ("path", token_path),
     ]
     table_str = tabulate(
-        contents, headers=["API token", ""], tablefmt=TABLE_FORMAT)
+        contents, headers=["API token", ""], tablefmt=_TABLE_FORMAT)
     print(table_str)
 
 
@@ -1731,12 +1730,12 @@ def _print_data_table(data, show_count=False, show_all_fields=False):
     _render_fields(data, render_fcns)
 
     if show_all_fields:
-        table_str = tabulate(data, headers="keys", tablefmt=TABLE_FORMAT)
+        table_str = tabulate(data, headers="keys", tablefmt=_TABLE_FORMAT)
     else:
         fields = [
             "id", "name", "size", "type", "upload_date", "expiration_date"]
         records = _render_records(data, fields)
-        table_str = tabulate(records, headers=fields, tablefmt=TABLE_FORMAT)
+        table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
 
     print(table_str)
     if show_count:
@@ -1744,7 +1743,7 @@ def _print_data_table(data, show_count=False, show_all_fields=False):
 
 
 def _print_data_uploads(uploads):
-    table_str = tabulate(uploads, headers="keys", tablefmt=TABLE_FORMAT)
+    table_str = tabulate(uploads, headers="keys", tablefmt=_TABLE_FORMAT)
     print("\n" + table_str + "\n")
 
 
@@ -1757,13 +1756,13 @@ def _print_jobs_table(jobs, show_count=False, show_all_fields=False):
     _render_fields(jobs, render_fcns)
 
     if show_all_fields:
-        table_str = tabulate(jobs, headers="keys", tablefmt=TABLE_FORMAT)
+        table_str = tabulate(jobs, headers="keys", tablefmt=_TABLE_FORMAT)
     else:
         fields = [
             "id", "name", "state", "archived", "upload_date",
             "expiration_date"]
         records = _render_records(jobs, fields)
-        table_str = tabulate(records, headers=fields, tablefmt=TABLE_FORMAT)
+        table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
 
     print(table_str)
     if show_count:
@@ -1780,13 +1779,13 @@ def _print_analytics_table(analytics, show_count=False, show_all_fields=False):
     _render_fields(analytics, render_fcns)
 
     if show_all_fields:
-        table_str = tabulate(analytics, headers="keys", tablefmt=TABLE_FORMAT)
+        table_str = tabulate(analytics, headers="keys", tablefmt=_TABLE_FORMAT)
     else:
         fields = [
             "id", "name", "version", "scope", "supports_cpu", "supports_gpu",
             "pending", "upload_date"]
         records = _render_records(analytics, fields)
-        table_str = tabulate(records, headers=fields, tablefmt=TABLE_FORMAT)
+        table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
 
     print(table_str)
     if show_count:
@@ -1801,13 +1800,13 @@ def _print_dict_as_json(d):
 def _print_dict_as_table(d):
     contents = list(d.items())
     table_str = tabulate(
-        contents, headers=["Analytic", ""], tablefmt=TABLE_FORMAT)
+        contents, headers=["Analytic", ""], tablefmt=_TABLE_FORMAT)
     print(table_str)
 
 
 def _render_name(name):
-    if len(name) > MAX_NAME_COLUMN_WIDTH:
-        name = name[:(MAX_NAME_COLUMN_WIDTH - 4)] + " ..."
+    if len(name) > _MAX_NAME_COLUMN_WIDTH:
+        name = name[:(_MAX_NAME_COLUMN_WIDTH - 4)] + " ..."
     return name
 
 

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -760,16 +760,19 @@ class UploadJobsCommand(Command):
 
     Examples:
         # Upload job request
-        voxel51 jobs upload '/path/to/request.json'
+        voxel51 jobs upload --request '/path/to/request.json' \\
             --name <job-name> [--auto-start]
     '''
 
     @staticmethod
     def setup(parser):
-        parser.add_argument(
-            "path", metavar="PATH", help="job request to upload")
-        parser.add_argument(
-            "-n", "--name", metavar="NAME", help="job name")
+        fields = parser.add_argument_group("required arguments")
+        fields.add_argument(
+            "-r", "--request", metavar="PATH", required=True,
+            help="path to job request to upload")
+        fields.add_argument(
+            "-n", "--name", metavar="NAME", required=True, help="job name")
+
         parser.add_argument(
             "--auto-start", action="store_true",
             help="whether to automatically start job")

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1738,7 +1738,7 @@ def _print_data_table(data, show_count=False, show_all_fields=False):
         total_size = _render_bytes(sum(d["size"] for d in data))
 
     render_fcns = {
-        "name": _render_name,
+        "name": _render_long_str,
         "size": _render_bytes,
         "upload_date": _render_datetime,
         "expiration_date": _render_datetime,
@@ -1766,7 +1766,7 @@ def _print_data_uploads(uploads):
 
 def _print_jobs_table(jobs, show_count=False, show_all_fields=False):
     render_fcns = {
-        "name": _render_name,
+        "name": _render_long_str,
         "upload_date": _render_datetime,
         "expiration_date": _render_datetime,
     }
@@ -1793,6 +1793,7 @@ def _print_analytics_table(analytics, show_count=False, show_all_fields=False):
         "supports_gpu": bool,
         "pending": bool,
         "upload_date": _render_datetime,
+        "description": _render_long_str,
     }
     _render_fields(analytics, render_fcns)
 
@@ -1823,7 +1824,7 @@ def _print_dict_as_table(d):
     print(table_str)
 
 
-def _render_name(name):
+def _render_long_str(name):
     if len(name) > _MAX_NAME_COLUMN_WIDTH:
         name = name[:(_MAX_NAME_COLUMN_WIDTH - 4)] + " ..."
     return name

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -156,6 +156,7 @@ class DataCommand(Command):
         _register_command(subparsers, "list", ListDataCommand)
         _register_command(subparsers, "info", InfoDataCommand)
         _register_command(subparsers, "upload", UploadDataCommand)
+        _register_command(subparsers, "post-url", PostURLDataCommand)
         _register_command(subparsers, "download", DownloadDataCommand)
         _register_command(subparsers, "ttl", TTLDataCommand)
         _register_command(subparsers, "delete", DeleteDataCommand)
@@ -311,6 +312,55 @@ class UploadDataCommand(Command):
 
         if not args.print_id:
             _print_data_uploads(uploads)
+
+
+class PostURLDataCommand(Command):
+    '''Posts data via URL to the platform.
+
+    Examples:
+        # Post data via URL
+        voxel51 data post-url \\
+            --url <url> \\
+            --filename <filename> \\
+            --mime-type <mime-type> \\
+            --size <size-bytes> \\
+            --expiration-date <expiration-date>
+    '''
+
+    @staticmethod
+    def setup(parser):
+        fields = parser.add_argument_group("required arguments")
+        fields.add_argument(
+            "-u", "--url", metavar="URL", required=True, help="the data URL")
+        fields.add_argument(
+            "-f", "--filename", metavar="NAME", required=True,
+            help="the data filename")
+        fields.add_argument(
+            "-m", "--mime-type", metavar="TYPE", required=True,
+            help="the data MIME type")
+        fields.add_argument(
+            "-s", "--size", metavar="SIZE", type=int, required=True,
+            help="the data size, in bytes")
+        fields.add_argument(
+            "-e", "--expiration-date", metavar="DATE", required=True,
+            help="the data expiration date")
+
+        parser.add_argument(
+            "--print-id", action="store_true",
+            help="whether to print only the ID of the uploaded data")
+
+    @staticmethod
+    def run(parser, args):
+        api = API()
+
+        metadata = api.post_data_as_url(
+            args.url, args.filename, args.mime_type, args.size,
+            args.expiration_date)
+
+        if args.print_id:
+            print(metadata["id"])
+        else:
+            _print_data_uploads([metadata])
 
 
 class DownloadDataCommand(Command):

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1769,6 +1769,9 @@ def _print_jobs_table(jobs, show_count=False, show_all_fields=False):
         "name": _render_long_str,
         "upload_date": _render_datetime,
         "expiration_date": _render_datetime,
+        "start_date": _render_datetime,
+        "completion_date": _render_datetime,
+        "auto_start": bool,
     }
     _render_fields(jobs, render_fcns)
 
@@ -1837,6 +1840,9 @@ def _render_bytes(size):
 
 
 def _render_datetime(datetime_str):
+    if not datetime_str:
+        return ""
+
     dt = dateutil.parser.isoparse(datetime_str)
     return dt.astimezone(get_localzone()).strftime("%Y-%m-%d %H:%M:%S %Z")
 
@@ -1851,7 +1857,7 @@ def _render_fields(d, render_fcns):
 def _render_records(d, fields):
     records = []
     for di in d:
-        records.append(tuple(di[f] for f in fields))
+        records.append(tuple(di.get(f, "") for f in fields))
     return records
 
 

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -307,7 +307,8 @@ class UploadDataCommand(Command):
             if args.print_id:
                 print(metadata["id"])
             else:
-                uploads.append({"id": metadata["id"], "path": path})
+                metadata["path"] = path
+                uploads.append(metadata)
 
         if not args.print_id:
             _print_data_uploads(uploads)

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1746,12 +1746,13 @@ def _print_data_table(data, show_count=False, show_all_fields=False):
     _render_fields(data, render_fcns)
 
     if show_all_fields:
-        table_str = tabulate(data, headers="keys", tablefmt=_TABLE_FORMAT)
+        fields = DataQuery.SUPPORTED_FIELDS
     else:
         fields = [
             "id", "name", "size", "type", "upload_date", "expiration_date"]
-        records = _render_records(data, fields)
-        table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
+
+    records = _render_records(data, fields)
+    table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
 
     print(table_str)
     if show_count:
@@ -1772,13 +1773,14 @@ def _print_jobs_table(jobs, show_count=False, show_all_fields=False):
     _render_fields(jobs, render_fcns)
 
     if show_all_fields:
-        table_str = tabulate(jobs, headers="keys", tablefmt=_TABLE_FORMAT)
+        fields = JobsQuery.SUPPORTED_FIELDS
     else:
         fields = [
             "id", "name", "state", "archived", "upload_date",
             "expiration_date"]
-        records = _render_records(jobs, fields)
-        table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
+
+    records = _render_records(jobs, fields)
+    table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
 
     print(table_str)
     if show_count:
@@ -1795,13 +1797,14 @@ def _print_analytics_table(analytics, show_count=False, show_all_fields=False):
     _render_fields(analytics, render_fcns)
 
     if show_all_fields:
-        table_str = tabulate(analytics, headers="keys", tablefmt=_TABLE_FORMAT)
+        fields = AnalyticsQuery.SUPPORTED_FIELDS
     else:
         fields = [
             "id", "name", "version", "scope", "supports_cpu", "supports_gpu",
             "pending", "upload_date"]
-        records = _render_records(analytics, fields)
-        table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
+
+    records = _render_records(analytics, fields)
+    table_str = tabulate(records, headers=fields, tablefmt=_TABLE_FORMAT)
 
     print(table_str)
     if show_count:

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -261,7 +261,7 @@ class API(object):
         '''
         endpoint = voxu.urljoin(
             self.base_url, "analytics", analytic_id, "images")
-        params = {"type": image_type.lower()}
+        params = {"type": image_type}
         filename = os.path.basename(image_tar_path)
         mime_type = _get_mime_type(image_tar_path)
         with open(image_tar_path, "rb") as df:

--- a/voxel51/users/query.py
+++ b/voxel51/users/query.py
@@ -37,8 +37,11 @@ class BaseQuery(object):
         limit (int): the maximum number of records to return
     '''
 
-    def __init__(self, supported_fields):
-        self._supported_fields = supported_fields
+    # Supported query fields. Subclasses must set this
+    SUPPORTED_FIELDS = None
+
+    def __init__(self):
+        '''Initializes the BaseQuery.'''
         self.fields = []
         self.search = []
         self.sort = None
@@ -80,7 +83,7 @@ class BaseQuery(object):
         Returns:
             the updated query instance
         '''
-        self.add_fields(self._supported_fields)
+        self.add_fields(self.SUPPORTED_FIELDS)
         return self
 
     def add_search(self, field, search_str):
@@ -210,7 +213,7 @@ class BaseQuery(object):
         return urlencode(self.to_dict())
 
     def _is_supported_field(self, field):
-        return field in self._supported_fields
+        return field in self.SUPPORTED_FIELDS
 
 
 class AnalyticsQuery(BaseQuery):
@@ -232,11 +235,13 @@ class AnalyticsQuery(BaseQuery):
             in the query response. By default, this is False
     '''
 
+    SUPPORTED_FIELDS = [
+        "id", "name", "version", "upload_date", "scope", "supports_cpu",
+        "supports_gpu", "pending", "description"]
+
     def __init__(self):
         '''Initializes an AnalyticsQuery instance.'''
-        super(AnalyticsQuery, self).__init__([
-            "id", "name", "version", "upload_date", "description",
-            "scope", "supports_cpu", "supports_gpu", "pending"])
+        super(AnalyticsQuery, self).__init__()
         self.all_versions = False
 
     def set_all_versions(self, all_versions):
@@ -269,11 +274,9 @@ class DataQuery(BaseQuery):
         limit (int): the maximum number of records to return
     '''
 
-    def __init__(self):
-        '''Initializes a DataQuery instance.'''
-        super(DataQuery, self).__init__([
-            "id", "name", "encoding", "type", "size", "upload_date",
-            "expiration_date"])
+    SUPPORTED_FIELDS = [
+        "id", "name", "encoding", "type", "size", "upload_date",
+        "expiration_date"]
 
 
 class JobsQuery(BaseQuery):
@@ -294,9 +297,7 @@ class JobsQuery(BaseQuery):
         limit (int): the maximum number of records to return
     '''
 
-    def __init__(self):
-        '''Initializes a JobsQuery instance.'''
-        super(JobsQuery, self).__init__([
-            "id", "name", "state", "archived", "upload_date", "analytic_id",
-            "auto_start", "compute_mode", "start_date", "completion_date",
-            "fail_date", "failure_type", "expiration_date"])
+    SUPPORTED_FIELDS = [
+        "id", "name", "state", "archived", "upload_date", "analytic_id",
+        "auto_start", "compute_mode", "start_date", "completion_date",
+        "fail_date", "failure_type", "expiration_date"]

--- a/voxel51/users/query.py
+++ b/voxel51/users/query.py
@@ -224,9 +224,9 @@ class AnalyticsQuery(BaseQuery):
 
     Attributes:
         fields (list): the list of fields to include in the returned records.
-            The supported query fields are `id`, `name`, `version`,
-            `upload_date`, `description`, `scope`, `supports_cpu`,
-            `supports_gpu`, and `pending`
+            The supported query fields are `id`, `name`, `version`, `scope`,
+            `supports_cpu`, `supports_gpu`, `pending`, `upload_date`, and
+            `description`
         search (list): a list of `field:search_str` search strings to apply
         sort (str): a `field:asc/desc` string describing a sorting scheme
         offset (int): an offset index for the returned records list
@@ -236,8 +236,8 @@ class AnalyticsQuery(BaseQuery):
     '''
 
     SUPPORTED_FIELDS = [
-        "id", "name", "version", "upload_date", "scope", "supports_cpu",
-        "supports_gpu", "pending", "description"]
+        "id", "name", "version", "scope", "supports_cpu", "supports_gpu",
+        "pending", "upload_date", "description"]
 
     def __init__(self):
         '''Initializes an AnalyticsQuery instance.'''
@@ -266,8 +266,8 @@ class DataQuery(BaseQuery):
 
     Attributes:
         fields (list): the list of fields to include in the returned records.
-            The supported query fields are `id`, `name`, `encoding`, `type`,
-            `size`, `upload_date`, and `expiration_date`
+            The supported query fields are `id`, `name`, `size`, `type`,
+            `upload_date`, `expiration_date`, and `encoding`
         search (list): a list of `field:search_str` search strings to apply
         sort (str): a `field:asc/desc` string describing a sorting scheme
         offset (int): an offset index for the returned records list
@@ -275,8 +275,8 @@ class DataQuery(BaseQuery):
     '''
 
     SUPPORTED_FIELDS = [
-        "id", "name", "encoding", "type", "size", "upload_date",
-        "expiration_date"]
+        "id", "name", "size", "type", "upload_date", "expiration_date",
+        "encoding"]
 
 
 class JobsQuery(BaseQuery):
@@ -288,9 +288,10 @@ class JobsQuery(BaseQuery):
     Attributes:
         fields (list): the list of fields to include in the returned records.
             The supported query fields are `id`, `name`, `state`, `archived`,
-            `upload_date`, `analytic_id`, `auto_start`, `compute_mode`,
-            `start_date`, `completion_date`, `fail_date`, `failure_type`, and
-            `expiration_date`
+            `upload_date`, `expiration_date`, `analytic_id`, `compute_mode`,
+            `auto_start`, `start_date`, `completion_date`, `fail_date`, and
+            `failure_type`
+
         search (list): a list of `field:search_str` search strings to apply
         sort (str): a `field:asc/desc` string describing a sorting scheme
         offset (int): an offset index for the returned records list
@@ -298,6 +299,6 @@ class JobsQuery(BaseQuery):
     '''
 
     SUPPORTED_FIELDS = [
-        "id", "name", "state", "archived", "upload_date", "analytic_id",
-        "auto_start", "compute_mode", "start_date", "completion_date",
-        "fail_date", "failure_type", "expiration_date"]
+        "id", "name", "state", "archived", "upload_date", "expiration_date",
+        "analytic_id", "compute_mode", "auto_start", "start_date",
+        "completion_date", "fail_date", "failure_type"]


### PR DESCRIPTION
Adds a `voxel51 data post-url` command for posting data as URL.

Also splits analytic upload into two commands:
- `voxel51 analytics upload`: upload new analytics (doc JSON)
- `voxel51 analytics upload-image`: upload image for analytic

The latter change clarifies what was previously a confusing command with optional flags from two actions merged together.