### PR TITLE
Adding support for setting token private key via environment variable

### DIFF
--- a/APPLICATIONS.md
+++ b/APPLICATIONS.md
@@ -39,8 +39,15 @@ variable in your shell to point to your API token file:
 export VOXEL51_APP_TOKEN=/path/to/your/app-token.json
 ```
 
-Alternatively, you can permanently activate an application token by executing
-the following commands:
+Alternatively, you can directly set the `VOXEL51_APP_PRIVATE_KEY` environment
+variable in your shell to the private key of your API token:
+
+```shell
+export VOXEL51_APP_PRIVATE_KEY=XXXXXXXX
+```
+
+Finally, you can permanently activate an application token by executing the
+following commands:
 
 ```py
 from voxel51.apps.auth import activate_application_token

--- a/CLI.md
+++ b/CLI.md
@@ -28,7 +28,14 @@ to your API token file:
 export VOXEL51_API_TOKEN=/path/to/your/api-token.json
 ```
 
-Alternatively, you can permanently activate a token by executing the following
+Alternatively, you can directly set the `VOXEL51_API_PRIVATE_KEY` environment
+variable in your shell to the private key of your API token:
+
+```shell
+export VOXEL51_API_PRIVATE_KEY=XXXXXXXX
+```
+
+Finally, you can permanently activate a token by executing the following
 commands:
 
 ```shell
@@ -43,9 +50,10 @@ To show information about your active token, you can execute:
 ```shell
 $ voxel51 auth show
 API token
--------------  ------------------------------------
-id             2649113c-e5ca-4008-a2f3-a24a9db806b9
+-------------  ---------------------------------------------------
+token id       2649113c-e5ca-4008-a2f3-a24a9db806b9
 creation date  2018-11-30 01:12:28 EST
+private key    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyYW5kIj ...
 base api url   https://api.voxel51.com
 path           /path/to/your/api-token.json
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,14 @@ to your API token file:
 export VOXEL51_API_TOKEN=/path/to/your/api-token.json
 ```
 
-Alternatively, you can permanently activate a token by executing the following
+Alternatively, you can directly set the `VOXEL51_API_PRIVATE_KEY` environment
+variable in your shell to the private key of your API token:
+
+```shell
+export VOXEL51_API_PRIVATE_KEY=XXXXXXXX
+```
+
+Finally, you can permanently activate a token by executing the following
 commands:
 
 ```py

--- a/pylintrc
+++ b/pylintrc
@@ -67,7 +67,7 @@ confidence=
 # --disable=W"
 #disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
 
-disable=too-few-public-methods,too-many-instance-attributes,too-many-arguments,too-many-locals,too-many-lines,non-iterator-returned,too-many-statements,useless-object-inheritance,abstract-method,too-many-ancestors,too-many-branches
+disable=too-few-public-methods,too-many-instance-attributes,too-many-arguments,too-many-locals,too-many-lines,non-iterator-returned,too-many-statements,useless-object-inheritance,abstract-method,too-many-ancestors,too-many-branches,too-many-public-methods
 
 
 [REPORTS]

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -60,8 +60,9 @@ class ApplicationAPI(API):
 
         Args:
             token (voxel51.apps.auth.ApplicationToken, optional): an optional
-                :class:`voxel51.apps.auth.ApplicationToken` to use. If none,
-                the strategy described above is used to locate the active token
+                :class:`voxel51.apps.auth.ApplicationToken` to use. If no
+                token is provided, the strategy described above is used to
+                locate the active token
             keep_alive (bool, optional): whether to keep the request session
                 alive between requests. By default, this is False
         '''

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -35,6 +35,16 @@ class ApplicationAPI(API):
     platform users. In order to use these user-specific methods, however, you
     must first activate a user via :func:`ApplicationAPI.with_user`.
 
+    Using this API requires a valid application token. The following strategy
+    is used to locate your active application token:
+
+        (1) Use the :class:`voxel51.apps.auth.ApplicationToken` provided when
+            constructing the :class:`ApplicationAPI` instance
+        (2) Use the ``VOXEL51_APP_PRIVATE_KEY`` and ``VOXEL51_APP_BASE_URL``
+            environment variables
+        (3) Use the ``VOXEL51_APP_TOKEN`` environment variable
+        (4) Load the active token from ``~/.voxel51/app-token.json``
+
     Attributes:
         base_url (str): the base URL of the API
         token (voxel51.apps.auth.ApplicationToken): the authentication token
@@ -50,10 +60,8 @@ class ApplicationAPI(API):
 
         Args:
             token (voxel51.apps.auth.ApplicationToken, optional): an optional
-                :class:`ApplicationToken` to use. If no token is provided, the
-                ``VOXEL51_APP_TOKEN`` environment variable is checked and, if
-                set, the token is loaded from that path. Otherwise, the token
-                is loaded from ``~/.voxel51/app-token.json``
+                :class:`voxel51.apps.auth.ApplicationToken` to use. If none,
+                the strategy described above is used to locate the active token
             keep_alive (bool, optional): whether to keep the request session
                 alive between requests. By default, this is False
         '''

--- a/voxel51/apps/api.py
+++ b/voxel51/apps/api.py
@@ -36,7 +36,7 @@ class ApplicationAPI(API):
     must first activate a user via :func:`ApplicationAPI.with_user`.
 
     Using this API requires a valid application token. The following strategy
-    is used to locate your active application token:
+    is used to locate your active application token (in order of precedence):
 
         (1) Use the :class:`voxel51.apps.auth.ApplicationToken` provided when
             constructing the :class:`ApplicationAPI` instance

--- a/voxel51/apps/auth.py
+++ b/voxel51/apps/auth.py
@@ -95,7 +95,8 @@ def get_active_application_token_path():
 def load_application_token(token_path=None):
     '''Loads the active application token.
 
-    The following strategy is used to locate the active API token:
+    The following strategy is used to locate the active API token (in order of
+    precedence):
 
         (1) Use the provided ``token_path``
         (2) Use the ``VOXEL51_APP_PRIVATE_KEY`` and ``VOXEL51_APP_BASE_URL``

--- a/voxel51/apps/auth.py
+++ b/voxel51/apps/auth.py
@@ -120,8 +120,8 @@ def load_application_token(token_path=None):
 
     # Load token from environment variables, if possible
     private_key = os.environ.get(PRIVATE_KEY_ENV_VAR, None)
-    base_api_url = os.environ.get(BASE_API_URL_ENV_VAR, None)
     if private_key:
+        base_api_url = os.environ.get(BASE_API_URL_ENV_VAR, None)
         return ApplicationToken.from_private_key(
             private_key, base_api_url=base_api_url)
 

--- a/voxel51/apps/auth.py
+++ b/voxel51/apps/auth.py
@@ -135,8 +135,7 @@ def load_application_token(token_path=None):
 
 def _load_application_token_from_path(token_path):
     if not os.path.isfile(token_path):
-        raise ApplicationTokenError(
-            "No application token found at '%s'" % token_path)
+        raise ApplicationTokenError("No file found at '%s'" % token_path)
 
     try:
         return ApplicationToken.from_json(token_path)

--- a/voxel51/cli/cli.py
+++ b/voxel51/cli/cli.py
@@ -1726,6 +1726,7 @@ def _print_active_token_info():
     contents = [
         ("token id", token.id),
         ("creation date", _render_datetime(token.creation_date)),
+        ("private key", _render_long_str(token.private_key)),
         ("base api url", token.base_api_url),
         ("path", token_path),
     ]

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -51,6 +51,16 @@ class AnalyticImageType(object):
 class API(object):
     '''Main class for managing a session with the Voxel51 Platform API.
 
+    Using this API requires a valid API token. The following strategy is used
+    to locate your active API token:
+
+        (1) Use the :class:`voxel51.users.auth.Token` provided when
+            constructing the :class:`API` instance
+        (2) Use the ``VOXEL51_API_PRIVATE_KEY`` and ``VOXEL51_API_BASE_URL``
+            environment variables
+        (3) Use the ``VOXEL51_API_TOKEN`` environment variable
+        (4) Load the active token from ``~/.voxel51/api-token.json``
+
     Attributes:
         base_url (string): the base URL of the API
         token (voxel51.users.auth.Token): the authentication token for this
@@ -63,11 +73,9 @@ class API(object):
         '''Creates an API instance.
 
         Args:
-            token (voxel51.users.auth.Token, optional): a Token to use. If no
-                token is provided, the ``VOXEL51_API_TOKEN`` environment
-                variable is checked and, if set, the token is loaded from that
-                path. Otherwise, the token is loaded from
-                ``~/.voxel51/api-token.json``
+            token (voxel51.users.auth.Token, optional): a
+                :class:`voxel51.users.auth.Token` to use. If none, the strategy
+                described above is used to locate the active token
             keep_alive (bool, optional): whether to keep the request session
                 alive between requests. By default, this is False
         '''

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -52,7 +52,7 @@ class API(object):
     '''Main class for managing a session with the Voxel51 Platform API.
 
     Using this API requires a valid API token. The following strategy is used
-    to locate your active API token:
+    to locate your active API token (in order of precedence):
 
         (1) Use the :class:`voxel51.users.auth.Token` provided when
             constructing the :class:`API` instance

--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -74,8 +74,9 @@ class API(object):
 
         Args:
             token (voxel51.users.auth.Token, optional): a
-                :class:`voxel51.users.auth.Token` to use. If none, the strategy
-                described above is used to locate the active token
+                :class:`voxel51.users.auth.Token` to use. If no token is
+                provided, the strategy described above is used to locate the
+                active token
             keep_alive (bool, optional): whether to keep the request session
                 alive between requests. By default, this is False
         '''

--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -93,7 +93,8 @@ def get_active_token_path():
 def load_token(token_path=None):
     '''Loads the active API token.
 
-    The following strategy is used to locate the active API token:
+    The following strategy is used to locate the active API token (in order of
+    precedence):
 
         (1) Use the provided ``token_path``
         (2) Use the ``VOXEL51_API_PRIVATE_KEY`` and ``VOXEL51_API_BASE_URL``

--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -33,7 +33,7 @@ BASE_API_URL_ENV_VAR = "VOXEL51_API_BASE_URL"
 TOKEN_PATH = os.path.join(
     os.path.expanduser("~"), ".voxel51", "api-token.json")
 
-DEAFULT_BASE_API_URL = "https://api.voxel51.com"
+DEFAULT_BASE_API_URL = "https://api.voxel51.com"
 HELP_URL = "https://voxel51.com/docs/api/?python#authentication"
 
 
@@ -202,7 +202,7 @@ class Token(object):
         return cls({
             "access_token": {
                 "private_key": private_key,
-                "base_api_url": base_api_url or DEAFULT_BASE_API_URL,
+                "base_api_url": base_api_url or DEFAULT_BASE_API_URL,
             }
         })
 
@@ -210,7 +210,7 @@ class Token(object):
     def _parse_base_api_url(access_token):
         base_api_url = access_token.get("base_api_url", None)
         if base_api_url is None:
-            base_api_url = DEAFULT_BASE_API_URL
+            base_api_url = DEFAULT_BASE_API_URL
             logger.warning(
                 "No base API URL found in token; defaulting to '%s'. To "
                 "resolve this message, download a new API token from the "

--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -26,10 +26,14 @@ import voxel51.users.utils as voxu
 logger = logging.getLogger(__name__)
 
 
-TOKEN_ENVIRON_VAR = "VOXEL51_API_TOKEN"
+TOKEN_ENV_VAR = "VOXEL51_API_TOKEN"
+PRIVATE_KEY_ENV_VAR = "VOXEL51_API_PRIVATE_KEY"
+BASE_API_URL_ENV_VAR = "VOXEL51_API_BASE_URL"
+
 TOKEN_PATH = os.path.join(
     os.path.expanduser("~"), ".voxel51", "api-token.json")
 
+DEAFULT_BASE_API_URL = "https://api.voxel51.com"
 HELP_URL = "https://voxel51.com/docs/api/?python#authentication"
 
 
@@ -59,27 +63,29 @@ def deactivate_token():
 
 
 def get_active_token_path():
-    '''Gets the path to the active API token.
+    '''Gets the path to the active API token, if any.
 
     If the ``VOXEL51_API_TOKEN`` environment variable is set, that path is
     used. Otherwise, ``~/.voxel51/api-token.json`` is used.
 
-    Returns:
-        the path to the active token
+    Note that if the ``VOXEL51_API_PRIVATE_KEY`` environment variable is set,
+    this function will always return None, since that environment variable
+    always takes precedence over other methods for locating the active token.
 
-    Raises:
-        :class:`TokenError` if no token was found
+    Returns:
+        the path to the active token, or None if no token was found
     '''
-    token_path = os.environ.get(TOKEN_ENVIRON_VAR, None)
+    private_key = os.environ.get(PRIVATE_KEY_ENV_VAR, None)
+    if private_key:
+        return None
+
+    token_path = os.environ.get(TOKEN_ENV_VAR, None)
     if token_path is not None:
         if not os.path.isfile(token_path):
             raise TokenError(
-                "No API token found at '%s=%s'" %
-                (TOKEN_ENVIRON_VAR, token_path))
+                "No file found at '%s=%s'" % (TOKEN_ENV_VAR, token_path))
     elif os.path.isfile(TOKEN_PATH):
         token_path = TOKEN_PATH
-    else:
-        raise TokenError("No API token found")
 
     return token_path
 
@@ -87,11 +93,18 @@ def get_active_token_path():
 def load_token(token_path=None):
     '''Loads the active API token.
 
+    The following strategy is used to locate the active API token:
+
+        (1) Use the provided ``token_path``
+        (2) Use the ``VOXEL51_API_PRIVATE_KEY`` and ``VOXEL51_API_BASE_URL``
+            environment variables
+        (3) Use the ``VOXEL51_API_TOKEN`` environment variable
+        (4) Load the active token from ``~/.voxel51/api-token.json``
+
     Args:
         token_path (str, optional): the path to a :class:`Token` JSON file.
-            If no path is provided, the ``VOXEL51_API_TOKEN`` environment
-            variable is checked and, if set, the token is loaded from that
-            path. Otherwise, it is loaded from ``~/.voxel51/api-token.json``
+            If no path is provided, the active token is loaded using the
+            strategy described above
 
     Returns:
         a :class:`Token` instance
@@ -99,9 +112,26 @@ def load_token(token_path=None):
     Raises:
         :class:`TokenError` if no valid token was found
     '''
-    if token_path is None:
-        token_path = get_active_token_path()
-    elif not os.path.isfile(token_path):
+    # Load token from provided path
+    if token_path is not None:
+        return _load_token_from_path(token_path)
+
+    # Load token from environment variables, if possible
+    private_key = os.environ.get(PRIVATE_KEY_ENV_VAR, None)
+    base_api_url = os.environ.get(BASE_API_URL_ENV_VAR, None)
+    if private_key:
+        return Token.from_private_key(private_key, base_api_url=base_api_url)
+
+    # Try to load token from path
+    token_path = get_active_token_path()
+    if token_path is not None:
+        return _load_token_from_path(token_path)
+
+    raise TokenError("No API token found")
+
+
+def _load_token_from_path(token_path):
+    if not os.path.isfile(token_path):
         raise TokenError("No API token found at '%s'" % token_path)
 
     try:
@@ -117,6 +147,7 @@ class Token(object):
         base_api_url (str): the base URL of the API for the token
         creation_date (str): the creation date of the token
         id (str): the ID of the token
+        private_key (str): the private key of the token
     '''
 
     def __init__(self, token_dict):
@@ -127,9 +158,9 @@ class Token(object):
         '''
         access_token = token_dict["access_token"]
         self.base_api_url = self._parse_base_api_url(access_token)
-        self.creation_date = access_token["created_at"]
-        self.id = access_token["token_id"]
-        self._private_key = access_token["private_key"]
+        self.creation_date = access_token.get("created_at", None)
+        self.id = access_token.get("token_id", None)
+        self.private_key = access_token["private_key"]
         self._token_dict = token_dict
 
     def __str__(self):
@@ -142,7 +173,7 @@ class Token(object):
         Returns:
             a header dictionary
         '''
-        return {"Authorization": "Bearer " + self._private_key}
+        return {"Authorization": "Bearer " + self.private_key}
 
     @classmethod
     def from_json(cls, path):
@@ -156,11 +187,30 @@ class Token(object):
         '''
         return cls(voxu.read_json(path))
 
+    @classmethod
+    def from_private_key(cls, private_key, base_api_url=None):
+        '''Builds a Token from its private key.
+
+        Args:
+            private_key (str): the private key of the token
+            base_api_url (str, optional): the base URL of the API for the
+                token. If none, the default platform API is assumed
+
+        Returns:
+            a Token instance
+        '''
+        return cls({
+            "access_token": {
+                "private_key": private_key,
+                "base_api_url": base_api_url or DEAFULT_BASE_API_URL,
+            }
+        })
+
     @staticmethod
     def _parse_base_api_url(access_token):
         base_api_url = access_token.get("base_api_url", None)
         if base_api_url is None:
-            base_api_url = "https://api.voxel51.com"
+            base_api_url = DEAFULT_BASE_API_URL
             logger.warning(
                 "No base API URL found in token; defaulting to '%s'. To "
                 "resolve this message, download a new API token from the "

--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -132,7 +132,7 @@ def load_token(token_path=None):
 
 def _load_token_from_path(token_path):
     if not os.path.isfile(token_path):
-        raise TokenError("No API token found at '%s'" % token_path)
+        raise TokenError("No file found at '%s'" % token_path)
 
     try:
         return Token.from_json(token_path)

--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -118,8 +118,8 @@ def load_token(token_path=None):
 
     # Load token from environment variables, if possible
     private_key = os.environ.get(PRIVATE_KEY_ENV_VAR, None)
-    base_api_url = os.environ.get(BASE_API_URL_ENV_VAR, None)
     if private_key:
+        base_api_url = os.environ.get(BASE_API_URL_ENV_VAR, None)
         return Token.from_private_key(private_key, base_api_url=base_api_url)
 
     # Try to load token from path


### PR DESCRIPTION
This now works! No more need to store a token JSON on disk:

```shell
export VOXEL51_API_PRIVATE_KEY=XXXXXXXX

voxel51 auth show
```

If you need to use an endpoint other than https://api.voxel51.com, you can do this:

```shell
export VOXEL51_API_PRIVATE_KEY=XXXXXXXX
export VOXEL51_API_BASE_URL=YYYYYYYY

voxel51 auth show
```