### PR TITLE
Adding support for loading Tokens from dict/str

### DIFF
--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -1,7 +1,7 @@
 '''
 Authentication module for the Voxel51 Platform API.
 
-| Copyright 2017-2019, Voxel51, Inc.
+| Copyright 2017-2020, Voxel51, Inc.
 | `voxel51.com <https://voxel51.com/>`_
 |
 '''
@@ -187,6 +187,30 @@ class Token(object):
             a Token instance
         '''
         return cls(voxu.read_json(path))
+
+    @classmethod
+    def from_dict(cls, token_dict):
+        '''Loads a Token from a JSON dictionary.
+
+        Args:
+            token_dict (dict): a JSON dictionary defining the Token
+
+        Returns:
+            a Token instance
+        '''
+        return cls(token_dict)
+
+    @classmethod
+    def from_str(cls, json_str):
+        '''Loads a Token from a JSON string.
+
+        Args:
+            json_str (str): a string representation of the Token
+
+        Returns:
+            a Token instance
+        '''
+        return cls(voxu.load_json(json_str))
 
     @classmethod
     def from_private_key(cls, private_key, base_api_url=None):

--- a/voxel51/users/auth.py
+++ b/voxel51/users/auth.py
@@ -201,16 +201,16 @@ class Token(object):
         return cls(token_dict)
 
     @classmethod
-    def from_str(cls, json_str):
+    def from_str(cls, token_str):
         '''Loads a Token from a JSON string.
 
         Args:
-            json_str (str): a string representation of the Token
+            token_str (str): a string representation of the Token
 
         Returns:
             a Token instance
         '''
-        return cls(voxu.load_json(json_str))
+        return cls(voxu.load_json(token_str))
 
     @classmethod
     def from_private_key(cls, private_key, base_api_url=None):


### PR DESCRIPTION
Methods 2 and 3 below are now supported:

```py
import voxel51.users.auth as voxa

# Load a token from JSON on disk
token1 = voxa.Token.from_json(token_path)

# Load a token from a JSON dictionary representation of it
token2 = voxa.Token.from_dict(token_dict)

# Load a token from JSON string
token3 = voxa.Token.from_str(token_str)
```