### PR TITLE
Adding method to get analytic ID by name + version

### DIFF
--- a/voxel51/users/api.py
+++ b/voxel51/users/api.py
@@ -208,14 +208,18 @@ class API(object):
             ValueError if the specified analytic was not (uniquely) found
         '''
         analytics_query = voxq.AnalyticsQuery()
-        analytics_query.add_field("id")
+        analytics_query.add_fields(["id", "name", "version"])
         analytics_query.add_search("name", name)
 
         if version is not None:
             analytics_query.add_search("version", version)
             analytics_query.set_all_versions(True)
 
-        analytics = self.query_analytics(analytics_query)["analytics"]
+        analytics = [
+            a for a in self.query_analytics(analytics_query)["analytics"]
+            if a["name"].lower() == name.lower() and (
+                version is None or a["version"].lower() == version.lower())
+        ]
 
         if len(analytics) != 1:
             pretty_name = _render_pretty_analytic_name(name, version=version)

--- a/voxel51/users/query.py
+++ b/voxel51/users/query.py
@@ -99,9 +99,6 @@ class BaseQuery(object):
         Returns:
             the updated query instance
         '''
-        if not self._is_supported_field(field):
-            raise ValueError("Invalid search parameter %s" % field)
-
         self.search.append("%s:%s" % (field, search_str))
         return self
 

--- a/voxel51/users/query.py
+++ b/voxel51/users/query.py
@@ -22,8 +22,6 @@ try:
 except ImportError:
     from urllib import urlencode  # Python 2
 
-from voxel51.users.api import APIError
-
 
 class BaseQuery(object):
     '''Base class for API queries.
@@ -102,7 +100,8 @@ class BaseQuery(object):
             the updated query instance
         '''
         if not self._is_supported_field(field):
-            raise APIError("Invalid search parameter %s" % field, 400)
+            raise ValueError("Invalid search parameter %s" % field)
+
         self.search.append("%s:%s" % (field, search_str))
         return self
 


### PR DESCRIPTION
Users run analytics via their `name` and `version`, so looking up analytics in this way is also a common use case that we should support.

Note that I am just implementing this clientside for now.